### PR TITLE
브랜드 단위/통합 테스트 작성

### DIFF
--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/brand/BrandEntity.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/brand/BrandEntity.kt
@@ -1,9 +1,14 @@
 package com.loopers.domain.brand
 
 import com.loopers.domain.BaseEntity
+import jakarta.persistence.*
 
+@Entity
+@Table(name = "brand")
 class BrandEntity(
+    @Column(unique = true)
     val name: String,
+    @Enumerated(EnumType.STRING)
     val status: BrandStatusType,
 ) : BaseEntity() {
 

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/brand/BrandEntity.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/brand/BrandEntity.kt
@@ -1,0 +1,24 @@
+package com.loopers.domain.brand
+
+import com.loopers.domain.BaseEntity
+
+class BrandEntity(
+    val name: String,
+    val status: BrandStatusType,
+) : BaseEntity() {
+
+    enum class BrandStatusType {
+        ACTIVE,
+        INACTIVE,
+        DELETED
+    }
+
+    init {
+        !name.matches(BRAND_NAME_REGEX) && throw IllegalArgumentException("브랜드명은 한글, 영문, 숫자 20자 이내로 입력해야 합니다.")
+
+    }
+
+    companion object {
+        private val BRAND_NAME_REGEX = "^[가-힣a-zA-Z0-9]{1,20}$".toRegex()
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/brand/BrandRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/brand/BrandRepository.kt
@@ -1,9 +1,15 @@
 package com.loopers.domain.brand
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.jpa.domain.Specification
+
 interface BrandRepository {
     fun save(brand: BrandEntity): BrandEntity
 
     fun findById(brandId: Long): BrandEntity?
 
     fun findByName(name: String): BrandEntity?
+
+    fun findAll(spec: Specification<BrandEntity>, pageRequest: PageRequest): Page<BrandEntity>
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/brand/BrandRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/brand/BrandRepository.kt
@@ -1,0 +1,9 @@
+package com.loopers.domain.brand
+
+interface BrandRepository {
+    fun save(brand: BrandEntity): BrandEntity
+
+    fun findById(brandId: Long): BrandEntity?
+
+    fun findByName(name: String): BrandEntity?
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/brand/BrandSearchCondition.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/brand/BrandSearchCondition.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.brand
+
+class BrandSearchCondition(
+    val name: String? = null,
+    val status: BrandEntity.BrandStatusType? = null,
+) {
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/brand/BrandService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/brand/BrandService.kt
@@ -1,0 +1,28 @@
+package com.loopers.domain.brand
+
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class BrandService(
+    private val brandRepository: BrandRepository,
+) {
+
+    @Transactional
+    fun createBrand(brand: BrandEntity): BrandEntity {
+        brandRepository.findByName(brand.name)?.let {
+            throw CoreException(
+                ErrorType.CONFLICT,
+                "이미 존재하는 브랜드입니다: ${brand.name}",
+            )
+        }
+        return brandRepository.save(brand)
+    }
+
+    @Transactional(readOnly = true)
+    fun findBrandBy(brandId: Long): BrandEntity? {
+        return brandRepository.findById(brandId)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/brand/BrandService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/brand/BrandService.kt
@@ -2,6 +2,10 @@ package com.loopers.domain.brand
 
 import com.loopers.support.error.CoreException
 import com.loopers.support.error.ErrorType
+import jakarta.persistence.criteria.Predicate
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.jpa.domain.Specification
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -22,7 +26,28 @@ class BrandService(
     }
 
     @Transactional(readOnly = true)
+    fun searchBrands(
+        condition: BrandSearchCondition, pageRequest: PageRequest
+    ): Page<BrandEntity> {
+        val spec = Specification<BrandEntity> { root, query, cb ->
+            val predicates = mutableListOf<Predicate>()
+
+            condition.name?.let {
+                predicates.add(cb.like(cb.lower(root.get("name")), "${it.lowercase()}%"))
+            }
+
+            condition.status?.let {
+                predicates.add(cb.equal(root.get<BrandEntity.BrandStatusType>("status"), it))
+            }
+
+            cb.and(*predicates.toTypedArray())
+        }
+        return brandRepository.findAll(spec, pageRequest)
+    }
+
+    @Transactional(readOnly = true)
     fun findBrandBy(brandId: Long): BrandEntity? {
         return brandRepository.findById(brandId)
     }
+
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/brand/BrandJpaRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/brand/BrandJpaRepository.kt
@@ -1,0 +1,8 @@
+package com.loopers.infrastructure.brand
+
+import com.loopers.domain.brand.BrandEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface BrandJpaRepository : JpaRepository<BrandEntity, Long> {
+    fun findByName(name: String): BrandEntity?
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/brand/BrandJpaRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/brand/BrandJpaRepository.kt
@@ -2,7 +2,8 @@ package com.loopers.infrastructure.brand
 
 import com.loopers.domain.brand.BrandEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 
-interface BrandJpaRepository : JpaRepository<BrandEntity, Long> {
+interface BrandJpaRepository : JpaRepository<BrandEntity, Long>, JpaSpecificationExecutor<BrandEntity> {
     fun findByName(name: String): BrandEntity?
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/brand/BrandRepositoryImpl.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/brand/BrandRepositoryImpl.kt
@@ -1,0 +1,23 @@
+package com.loopers.infrastructure.brand
+
+import com.loopers.domain.brand.BrandEntity
+import com.loopers.domain.brand.BrandRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class BrandRepositoryImpl(
+    private val brandJpaRepository: BrandJpaRepository,
+) : BrandRepository {
+
+    override fun save(brand: BrandEntity): BrandEntity {
+        return brandJpaRepository.save(brand)
+    }
+
+    override fun findById(brandId: Long): BrandEntity? {
+        return brandJpaRepository.findById(brandId).orElse(null)
+    }
+
+    override fun findByName(name: String): BrandEntity? {
+        return brandJpaRepository.findByName(name)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/brand/BrandRepositoryImpl.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/brand/BrandRepositoryImpl.kt
@@ -2,6 +2,9 @@ package com.loopers.infrastructure.brand
 
 import com.loopers.domain.brand.BrandEntity
 import com.loopers.domain.brand.BrandRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.jpa.domain.Specification
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -19,5 +22,11 @@ class BrandRepositoryImpl(
 
     override fun findByName(name: String): BrandEntity? {
         return brandJpaRepository.findByName(name)
+    }
+
+    override fun findAll(
+        spec: Specification<BrandEntity>, pageRequest: PageRequest,
+    ): Page<BrandEntity> {
+        return brandJpaRepository.findAll(spec, pageRequest)
     }
 }

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/brand/BrandEntityFixture.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/brand/BrandEntityFixture.kt
@@ -1,0 +1,19 @@
+package com.loopers.domain.brand
+
+class BrandEntityFixture {
+    private var name: String = "brandName"
+    private var status: BrandEntity.BrandStatusType = BrandEntity.BrandStatusType.ACTIVE
+
+    companion object {
+        fun aBrand(): BrandEntityFixture = BrandEntityFixture()
+    }
+
+    fun name(name: String): BrandEntityFixture = apply { this.name = name }
+
+    fun status(status: BrandEntity.BrandStatusType): BrandEntityFixture = apply { this.status = status }
+
+    fun build(): BrandEntity = BrandEntity(
+        name,
+        status,
+    )
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/brand/BrandEntityTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/brand/BrandEntityTest.kt
@@ -1,0 +1,67 @@
+package com.loopers.domain.brand
+
+import com.loopers.domain.brand.BrandEntityFixture.Companion.aBrand
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class BrandEntityTest {
+
+    /*
+    **🧱 단위 테스트**
+    - [ ]  브랜드명이 `한글, 영문, 숫자 20자 이내` 형식에 맞지 않으면, BrandEntity 생성에 실패한다.
+    - [ ]  브랜드명, 브랜드상태가 올바른 경우 BrandEntity를 생성한다.
+    */
+    @DisplayName("브랜드를 생성할 때, ")
+    @Nested
+    inner class Create {
+        @DisplayName("브랜드명이 `한글, 영문, 숫자 20자 이내` 형식에 맞지 않으면, BrandEntity 생성에 실패한다.")
+        @ParameterizedTest
+        @ValueSource(
+            strings = [
+                "", // 빈 문자열인 경우
+                "브랜드@이름", // 특수문자가 포함된 경우
+                "브랜드 이름", // 공백이 포함된 경우
+                "브랜드이름!", // 특수문자가 포함된 경우
+                "브랜드이름1234567890abcdef", // 길이가 21인 경우
+            ],
+        )
+        fun failsToCreateBrand_whenNameIsInvalid(invalidBrandName: String) {
+            // arrange
+
+            // act
+            val result = assertThrows<IllegalArgumentException> {
+                aBrand().name(invalidBrandName).build()
+            }
+
+            // assert
+            assertAll(
+                { assertThat(result).isInstanceOf(IllegalArgumentException::class.java) },
+                { assertThat(result.message).isEqualTo("브랜드명은 한글, 영문, 숫자 20자 이내로 입력해야 합니다.") },
+            )
+        }
+
+        @DisplayName("브랜드명, 브랜드상태가 올바른 경우 BrandEntity를 생성한다.")
+        @Test
+        fun createsBrand_whenNameAndStatusAreValid() {
+            // arrange
+            val validBrandName = "브랜드이름"
+            val validBrandStatus = BrandEntity.BrandStatusType.ACTIVE
+
+            // act
+            val brandEntity = aBrand()
+                .name(validBrandName)
+                .status(validBrandStatus)
+                .build()
+
+            // assert
+            assertThat(brandEntity.name).isEqualTo(validBrandName)
+            assertThat(brandEntity.status).isEqualTo(validBrandStatus)
+        }
+    }
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/brand/BrandServiceIntegrationTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/brand/BrandServiceIntegrationTest.kt
@@ -281,4 +281,47 @@ class BrandServiceIntegrationTest @Autowired constructor(
         }
 
     }
+
+    /*
+    **🔗 통합 테스트
+    - [ ] 브랜드 ID에 해당하는 브랜드가 존재하지 않을 경우, null을 반환한다.
+    - [ ] 브랜드 ID에 해당하는 브랜드가 존재할 경우, 해당 브랜드를 반환한다.
+    */
+    @DisplayName("브랜드를 조회할 때, ")
+    @Nested
+    inner class Get {
+        @DisplayName("브랜드 ID에 해당하는 브랜드가 존재하지 않을 경우, null을 반환한다.")
+        @Test
+        fun returnsNull_whenBrandDoesNotExist() {
+            // arrange
+            val nonExistentBrandId = 999L
+            val searchBrands = brandService.searchBrands(BrandSearchCondition(), PageRequest.of(0, 10))
+            assertThat(searchBrands).isEmpty()
+
+            // act
+            val brand = brandService.findBrandBy(nonExistentBrandId)
+
+            // assert
+            assertThat(brand).isNull()
+        }
+
+        @DisplayName("브랜드 ID에 해당하는 브랜드가 존재할 경우, 해당 브랜드를 반환한다.")
+        @Test
+        fun returnsBrand_whenBrandExists() {
+            // arrange
+            val brandEntity = aBrand().build()
+            val createdBrand = brandService.createBrand(brandEntity)
+
+            // act
+            val findBrand = brandService.findBrandBy(createdBrand.id)
+
+            // assert
+            assertAll(
+                { assertThat(findBrand).isNotNull() },
+                { assertThat(findBrand?.id).isEqualTo(createdBrand.id) },
+                { assertThat(findBrand?.name).isEqualTo(createdBrand.name) },
+                { assertThat(findBrand?.status).isEqualTo(createdBrand.status) },
+            )
+        }
+    }
 }

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/brand/BrandServiceIntegrationTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/brand/BrandServiceIntegrationTest.kt
@@ -1,0 +1,72 @@
+package com.loopers.domain.brand
+
+import com.loopers.domain.brand.BrandEntityFixture.Companion.aBrand
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import com.loopers.utils.DatabaseCleanUp
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class BrandServiceIntegrationTest @Autowired constructor(
+    private val brandService: BrandService,
+    private val databaseCleanUp: DatabaseCleanUp,
+) {
+
+    @AfterEach
+    fun tearDown() {
+        databaseCleanUp.truncateAllTables()
+    }
+
+    /*
+    **🔗 통합 테스트
+    - [ ] 브랜드명이 중복될 경우, 브랜드 등록에 실패한다.
+    - [ ] 브랜드명, 브랜드상태가 올바른 경우 브랜드를 등록한다.
+     */
+    @DisplayName("브랜드를 등록할 떄, ")
+    @Nested
+    inner class Create {
+        @DisplayName("브랜드명이 중복될 경우, 브랜드 등록에 실패한다.")
+        @Test
+        fun failsToCreateBrand_whenBrandNameIsDuplicate() {
+            // arrange
+            val brandEntity = aBrand().build()
+            brandService.createBrand(brandEntity)
+
+            // act
+            val exception = assertThrows<CoreException> {
+                brandService.createBrand(brandEntity)
+            }
+
+            // assert
+            assertAll(
+                { assertThat(exception.errorType).isEqualTo(ErrorType.CONFLICT) },
+                { assertThat(exception.message).contains("이미 존재하는 브랜드입니다: ${brandEntity.name}") },
+            )
+        }
+
+        @DisplayName("브랜드명, 브랜드상태가 올바른 경우 브랜드를 등록한다.")
+        @Test
+        fun createsBrand_whenBrandNameAndStatusAreValid() {
+            // arrange
+            val brandEntity = aBrand().build()
+
+            // act
+            val createdBrand = brandService.createBrand(brandEntity)
+
+            // assert
+            assertAll(
+                { assertThat(createdBrand.id).isNotNull() },
+                { assertThat(createdBrand.name).isEqualTo(brandEntity.name) },
+                { assertThat(createdBrand.status).isEqualTo(brandEntity.status) },
+            )
+        }
+    }
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/brand/BrandServiceIntegrationTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/brand/BrandServiceIntegrationTest.kt
@@ -5,14 +5,11 @@ import com.loopers.support.error.CoreException
 import com.loopers.support.error.ErrorType
 import com.loopers.utils.DatabaseCleanUp
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertAll
-import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 
 @SpringBootTest
 class BrandServiceIntegrationTest @Autowired constructor(
@@ -68,5 +65,220 @@ class BrandServiceIntegrationTest @Autowired constructor(
                 { assertThat(createdBrand.status).isEqualTo(brandEntity.status) },
             )
         }
+    }
+
+    /*
+    **🔗 통합 테스트
+    - [ ] 브랜드 목록은 페이지 번호와 페이지 크기를 기준으로 조회할 수 있다.
+    - [ ] 브랜드 목록은 브랜드명으로 부분 일치 (Like) 검색할 수 있으며 대소문자를 구분하지 않는다.
+    - [ ] 브랜드 목록은 브랜드 상태로 필터링할 수 있다.
+    - [ ] 브랜드명과 일치하는 브랜드 목록이 없을 경우 빈 목록을 반환한다.
+    - [ ] 브랜드 목록은 브랜드명 오름차순으로 정렬할 수 있다.
+    - [ ] 브랜드 목록은 브랜드명 내림차순으로 정렬할 수 있다.
+    - [ ] 브랜드 목록은 등록일 오름차순으로 정렬할 수 있다.
+    - [ ] 브랜드 목록은 등록일 내림차순으로 정렬할 수 있다.
+     */
+    @DisplayName("브랜드 목록을 조회할 때, ")
+    @Nested
+    inner class Search {
+        @DisplayName("브랜드 목록은 페이지 번호와 페이지 크기를 기준으로 조회할 수 있다.")
+        @Test
+        fun findsBrands_whenPageNumberAndSizeAreValid() {
+            // arrange
+            val brand1 = aBrand().name("브랜드A").build()
+            val brand2 = aBrand().name("브랜드B").build()
+            brandService.createBrand(brand1)
+            brandService.createBrand(brand2)
+
+            // act
+            val pageRequest = PageRequest.of(0, 10)
+            val brandsPage = brandService.searchBrands(BrandSearchCondition(), pageRequest)
+
+            // assert
+            assertAll(
+                { assertThat(brandsPage.totalElements).isEqualTo(2) },
+                { assertThat(brandsPage.content).hasSize(2) },
+                { assertThat(brandsPage.content[0].name).isEqualTo(brand1.name) },
+                { assertThat(brandsPage.content[0].status).isEqualTo(brand1.status) },
+                { assertThat(brandsPage.content[1].name).isEqualTo(brand2.name) },
+                { assertThat(brandsPage.content[1].status).isEqualTo(brand2.status) },
+            )
+        }
+
+        @DisplayName("브랜드 목록은 브랜드명으로 부분 일치 (Like) 검색할 수 있으며 대소문자를 구분하지 않는다.")
+        @Test
+        fun findsBrands_whenSearchingByPartialName() {
+            // arrange
+            val brand1 = aBrand().name("브랜드AAB").build()
+            val brand2 = aBrand().name("브랜드BA").build()
+            val brand3 = aBrand().name("브랜드ABB").build()
+            val brand4 = aBrand().name("브랜드aba").build()
+            brandService.createBrand(brand1)
+            brandService.createBrand(brand2)
+            brandService.createBrand(brand3)
+            brandService.createBrand(brand4)
+
+            // act
+            val condition = BrandSearchCondition(name = "브랜드A")
+            val pageRequest = PageRequest.of(0, 10)
+            val brandsPage = brandService.searchBrands(condition, pageRequest)
+
+            // assert
+            assertAll(
+                { assertThat(brandsPage.totalElements).isEqualTo(3) },
+                { assertThat(brandsPage.content).hasSize(3) },
+                { assertThat(brandsPage.content[0].name).isEqualTo(brand1.name) },
+                { assertThat(brandsPage.content[0].status).isEqualTo(brand1.status) },
+                { assertThat(brandsPage.content[1].name).isEqualTo(brand3.name) },
+                { assertThat(brandsPage.content[1].status).isEqualTo(brand3.status) },
+                { assertThat(brandsPage.content[2].name).isEqualTo(brand4.name) },
+                { assertThat(brandsPage.content[2].status).isEqualTo(brand4.status) },
+            )
+        }
+
+        @DisplayName("브랜드 목록은 브랜드 상태로 필터링할 수 있다.")
+        @Test
+        fun findsBrands_whenFilteringByStatus() {
+            // arrange
+            val activeBrand = aBrand().name("활성브랜드").status(BrandEntity.BrandStatusType.ACTIVE).build()
+            val inactiveBrand = aBrand().name("비활성브랜드").status(BrandEntity.BrandStatusType.INACTIVE).build()
+            brandService.createBrand(activeBrand)
+            brandService.createBrand(inactiveBrand)
+
+            // act
+            val condition = BrandSearchCondition(status = BrandEntity.BrandStatusType.ACTIVE)
+            val pageRequest = PageRequest.of(0, 10)
+            val brandsPage = brandService.searchBrands(condition, pageRequest)
+
+            // assert
+            assertAll(
+                { assertThat(brandsPage.totalElements).isEqualTo(1) },
+                { assertThat(brandsPage.content).hasSize(1) },
+                { assertThat(brandsPage.content[0].name).isEqualTo(activeBrand.name) },
+                { assertThat(brandsPage.content[0].status).isEqualTo(activeBrand.status) },
+            )
+        }
+
+        @DisplayName("브랜드명과 일치하는 브랜드 목록이 없을 경우 빈 목록을 반환한다.")
+        @Test
+        fun returnsEmptyList_whenNoBrandsMatchName() {
+            // arrange
+            val brand1 = aBrand().name("브랜드A").build()
+            val brand2 = aBrand().name("브랜드B").build()
+            brandService.createBrand(brand1)
+            brandService.createBrand(brand2)
+
+            // act
+            val condition = BrandSearchCondition(name = "브랜드C")
+            val pageRequest = PageRequest.of(0, 10)
+            val brandsPage = brandService.searchBrands(condition, pageRequest)
+
+            // assert
+            assertAll(
+                { assertThat(brandsPage.totalElements).isEqualTo(0) },
+                { assertThat(brandsPage.content).isEmpty() },
+            )
+        }
+
+        @DisplayName("브랜드 목록은 브랜드명 오름차순으로 정렬할 수 있다.")
+        @Test
+        fun findsBrands_whenSortingByNameAsc() {
+            // arrange
+            val brand1 = aBrand().name("브랜드A").build()
+            val brand2 = aBrand().name("브랜드B").build()
+            brandService.createBrand(brand1)
+            brandService.createBrand(brand2)
+
+            // act
+            val condition = BrandSearchCondition()
+            val pageRequest = PageRequest.of(0, 10, Sort.by("name").ascending())
+            val brandsPage = brandService.searchBrands(condition, pageRequest)
+
+            // assert
+            assertAll(
+                { assertThat(brandsPage.totalElements).isEqualTo(2) },
+                { assertThat(brandsPage.content).hasSize(2) },
+                { assertThat(brandsPage.content[0].name).isEqualTo(brand1.name) },
+                { assertThat(brandsPage.content[0].status).isEqualTo(brand1.status) },
+                { assertThat(brandsPage.content[1].name).isEqualTo(brand2.name) },
+                { assertThat(brandsPage.content[1].status).isEqualTo(brand2.status) },
+            )
+        }
+
+        @DisplayName("브랜드 목록은 브랜드명 내림차순으로 정렬할 수 있다.")
+        @Test
+        fun findsBrands_whenSortingByNameDesc() {
+            // arrange
+            val brand1 = aBrand().name("브랜드A").build()
+            val brand2 = aBrand().name("브랜드B").build()
+            brandService.createBrand(brand1)
+            brandService.createBrand(brand2)
+
+            // act
+            val condition = BrandSearchCondition()
+            val pageRequest = PageRequest.of(0, 10, Sort.by("name").descending())
+            val brandsPage = brandService.searchBrands(condition, pageRequest)
+
+            // assert
+            assertAll(
+                { assertThat(brandsPage.totalElements).isEqualTo(2) },
+                { assertThat(brandsPage.content).hasSize(2) },
+                { assertThat(brandsPage.content[0].name).isEqualTo(brand2.name) },
+                { assertThat(brandsPage.content[0].status).isEqualTo(brand2.status) },
+                { assertThat(brandsPage.content[1].name).isEqualTo(brand1.name) },
+                { assertThat(brandsPage.content[1].status).isEqualTo(brand1.status) },
+            )
+        }
+
+        @DisplayName("브랜드 목록은 등록일 오름차순으로 정렬할 수 있다.")
+        @Test
+        fun findsBrands_whenSortingByCreatedAtAsc() {
+            // arrange
+            val brand1 = aBrand().name("브랜드A").build()
+            val brand2 = aBrand().name("브랜드B").build()
+            brandService.createBrand(brand1)
+            brandService.createBrand(brand2)
+
+            // act
+            val condition = BrandSearchCondition()
+            val pageRequest = PageRequest.of(0, 10, Sort.by("createdAt").ascending())
+            val brandsPage = brandService.searchBrands(condition, pageRequest)
+
+            // assert
+            assertAll(
+                { assertThat(brandsPage.totalElements).isEqualTo(2) },
+                { assertThat(brandsPage.content).hasSize(2) },
+                { assertThat(brandsPage.content[0].name).isEqualTo(brand1.name) },
+                { assertThat(brandsPage.content[0].status).isEqualTo(brand1.status) },
+                { assertThat(brandsPage.content[1].name).isEqualTo(brand2.name) },
+                { assertThat(brandsPage.content[1].status).isEqualTo(brand2.status) },
+            )
+        }
+
+        @DisplayName("브랜드 목록은 등록일 내림차순으로 정렬할 수 있다.")
+        @Test
+        fun findsBrands_whenSortingByCreatedAtDesc() {
+            // arrange
+            val brand1 = aBrand().name("브랜드A").build()
+            val brand2 = aBrand().name("브랜드B").build()
+            brandService.createBrand(brand1)
+            brandService.createBrand(brand2)
+
+            // act
+            val condition = BrandSearchCondition()
+            val pageRequest = PageRequest.of(0, 10, Sort.by("createdAt").descending())
+            val brandsPage = brandService.searchBrands(condition, pageRequest)
+
+            // assert
+            assertAll(
+                { assertThat(brandsPage.totalElements).isEqualTo(2) },
+                { assertThat(brandsPage.content).hasSize(2) },
+                { assertThat(brandsPage.content[0].name).isEqualTo(brand2.name) },
+                { assertThat(brandsPage.content[0].status).isEqualTo(brand2.status) },
+                { assertThat(brandsPage.content[1].name).isEqualTo(brand1.name) },
+                { assertThat(brandsPage.content[1].status).isEqualTo(brand1.status) },
+            )
+        }
+
     }
 }

--- a/apps/commerce-api/src/test/kotlin/com/loopers/dto/PageRequestTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/dto/PageRequestTest.kt
@@ -1,0 +1,47 @@
+package com.loopers.dto
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertThrows
+import org.springframework.data.domain.PageRequest
+
+class PageRequestTest {
+    /*
+    **🔗 통합 테스트
+    - [ ] 페이지 번호가 음수일 경우 예외가 발생한다.
+    - [ ] 페이지 크기가 0 이하일 경우 예외가 발생한다.
+     */
+    @DisplayName("페이지 번호가 음수일 경우 예외가 발생한다.")
+    @Test
+    fun failsToSearchBrand_whenPageNumberIsNegative() {
+        // arrange
+
+        // act
+        val exception = assertThrows<IllegalArgumentException> {
+            PageRequest.of(-1, 10)
+        }
+
+        // assert
+        assertAll(
+            { assertThat(exception).isInstanceOf(IllegalArgumentException::class.java) },
+        )
+    }
+
+    @DisplayName("페이지 크기가 0 이하일 경우 예외가 발생한다.")
+    @Test
+    fun failsToSearchBrand_whenPageSizeIsZeroOrLess() {
+        // arrange
+
+        // act
+        val exception = assertThrows<IllegalArgumentException> {
+            PageRequest.of(0, 0)
+        }
+
+        // assert
+        assertAll(
+            { assertThat(exception).isInstanceOf(IllegalArgumentException::class.java) },
+        )
+    }
+}


### PR DESCRIPTION
* 브랜드 등록 단위 테스트
- [ ] 브랜드명이 `한글, 영문, 숫자 20자 이내` 형식에 맞지 않으면, BrandEntity 생성에 실패한다.
- [ ] 브랜드명, 브랜드상태가 올바른 경우 BrandEntity를 생성한다.

* 브랜드 등록 통합 테스트
- [ ] 브랜드명이 중복될 경우, 브랜드 등록에 실패한다.
- [ ] 브랜드명, 브랜드상태가 올바른 경우 브랜드를 등록한다.

* 브랜드 목록 조회 통합 테스트
- [ ] 브랜드 목록은 페이지 번호와 페이지 크기를 기준으로 조회할 수 있다.
- [ ] 브랜드 목록은 브랜드명으로 부분 일치 (Like) 검색할 수 있으며 대소문자를 구분하지 않는다.
- [ ] 브랜드 목록은 브랜드 상태로 필터링할 수 있다.
- [ ] 브랜드명과 일치하는 브랜드 목록이 없을 경우 빈 목록을 반환한다.
- [ ] 브랜드 목록은 브랜드명 오름차순으로 정렬할 수 있다.
- [ ] 브랜드 목록은 브랜드명 내림차순으로 정렬할 수 있다.
- [ ] 브랜드 목록은 등록일 오름차순으로 정렬할 수 있다.
- [ ] 브랜드 목록은 등록일 내림차순으로 정렬할 수 있다.

* 브랜드 상세 조회 통합 테스트
- [ ] 브랜드 ID에 해당하는 브랜드가 존재하지 않을 경우, null을 반환한다.
- [ ] 브랜드 ID에 해당하는 브랜드가 존재할 경우, 해당 브랜드를 반환한다.
