### PR TITLE
결제/결제 항목/결제 항목 목록 단위 테스트 작성

### DIFF
--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentEntity.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentEntity.kt
@@ -1,0 +1,28 @@
+package com.loopers.domain.payment
+
+import com.loopers.domain.BaseEntity
+import com.loopers.domain.payment.vo.PaymentItems
+import com.loopers.domain.vo.Price
+
+class PaymentEntity(
+    val orderId: Long,
+    val method: PaymentMethodType,
+    paymentItems: PaymentItems,
+) : BaseEntity() {
+    var status: PaymentStatusType
+    val totalAmount: Price = paymentItems.totalAmount()
+
+    init {
+        status = PaymentStatusType.PENDING
+    }
+
+    enum class PaymentStatusType {
+        PENDING,
+        COMPLETED,
+        FAILED
+    }
+
+    enum class PaymentMethodType {
+        POINT,
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentItemEntity.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/PaymentItemEntity.kt
@@ -1,0 +1,30 @@
+package com.loopers.domain.payment
+
+import com.loopers.domain.BaseEntity
+import com.loopers.domain.vo.Price
+
+class PaymentItemEntity(
+    val paymentId: Long,
+    val orderItemId: Long,
+    val amount: Price,
+) : BaseEntity() {
+    var status: PaymentItemStatusType
+
+    enum class PaymentItemStatusType {
+        PENDING,
+        COMPLETED,
+        FAILED
+    }
+
+    init {
+        status = PaymentItemStatusType.PENDING
+    }
+
+    fun complete() {
+        status = PaymentItemStatusType.COMPLETED
+    }
+
+    fun fail() {
+        status = PaymentItemStatusType.FAILED
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/vo/PaymentItems.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/payment/vo/PaymentItems.kt
@@ -1,0 +1,18 @@
+package com.loopers.domain.payment.vo
+
+import com.loopers.domain.payment.PaymentItemEntity
+import com.loopers.domain.vo.Price
+
+@JvmInline
+value class PaymentItems(
+    val items: List<PaymentItemEntity>,
+) {
+
+    init {
+        require(items.isNotEmpty()) { "주문 항목 목록은 비어있을 수 없습니다." }
+    }
+
+    fun totalAmount(): Price {
+        return Price(items.sumOf { it.amount.value })
+    }
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/payment/PaymentEntityTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/payment/PaymentEntityTest.kt
@@ -1,0 +1,76 @@
+package com.loopers.domain.payment
+
+import com.loopers.domain.payment.vo.PaymentItems
+import com.loopers.domain.vo.Price
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class PaymentEntityTest {
+    /*
+    **🧱 단위 테스트**
+    - [ ] 결제 정보를 생성하면 결제 금액과 결제 항목의 총 금액은 일치해야 한다.
+    - [ ] 결제 정볼르 생성하면 상태는 PENDING로 초기화된다.
+    - [ ] 결제 완료 처리 시 상태는 COMPLETED로 변경된다.
+    - [ ] 결제 실패 처리 시 상태는 FAILED로 변경된다.
+     */
+    @DisplayName("PaymentEntity를 생성할 때, ")
+    @Nested
+    inner class Create {
+        @DisplayName("결제 정보를 생성하면 결제 금액과 결제 항목의 총 금액은 일치해야 한다.")
+        @Test
+        fun totalAmountMatchesPaymentItems() {
+            // arrange
+            val paymentItem1 = PaymentItemEntity(1L, 1L, Price(1000L))
+            val paymentItem2 = PaymentItemEntity(2L, 2L, Price(2000L))
+
+            // act
+            val paymentEntity = PaymentEntity(1L, PaymentEntity.PaymentMethodType.POINT, PaymentItems(listOf(paymentItem1, paymentItem2)))
+
+            // assert
+            assertThat(paymentEntity.totalAmount).isEqualTo(Price(3000L))
+        }
+
+        @DisplayName("결제 정보를 생성하면 상태는 PENDING로 초기화된다.")
+        @Test
+        fun initialStatusIsPending() {
+            // arrange
+            val paymentItem = PaymentItemEntity(1L, 1L, Price(1000L))
+
+            // act
+            val paymentEntity = PaymentEntity(1L, PaymentEntity.PaymentMethodType.POINT, PaymentItems(listOf(paymentItem)))
+
+            // assert
+            assertThat(paymentEntity.status).isEqualTo(PaymentEntity.PaymentStatusType.PENDING)
+        }
+
+        @DisplayName("결제 완료 처리 시 상태는 COMPLETED로 변경된다.")
+        @Test
+        fun completePaymentChangesStatusToCompleted() {
+            // arrange
+            val paymentItem = PaymentItemEntity(1L, 1L, Price(1000L))
+            val paymentEntity = PaymentEntity(1L, PaymentEntity.PaymentMethodType.POINT, PaymentItems(listOf(paymentItem)))
+
+            // act
+            paymentEntity.status = PaymentEntity.PaymentStatusType.COMPLETED
+
+            // assert
+            assertThat(paymentEntity.status).isEqualTo(PaymentEntity.PaymentStatusType.COMPLETED)
+        }
+
+        @DisplayName("결제 실패 처리 시 상태는 FAILED로 변경된다.")
+        @Test
+        fun failPaymentChangesStatusToFailed() {
+            // arrange
+            val paymentItem = PaymentItemEntity(1L, 1L, Price(1000L))
+            val paymentEntity = PaymentEntity(1L, PaymentEntity.PaymentMethodType.POINT, PaymentItems(listOf(paymentItem)))
+
+            // act
+            paymentEntity.status = PaymentEntity.PaymentStatusType.FAILED
+
+            // assert
+            assertThat(paymentEntity.status).isEqualTo(PaymentEntity.PaymentStatusType.FAILED)
+        }
+    }
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/payment/PaymentItemEntityTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/payment/PaymentItemEntityTest.kt
@@ -1,0 +1,91 @@
+package com.loopers.domain.payment
+
+import com.loopers.domain.vo.Price
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class PaymentItemEntityTest {
+    /*
+    **🧱 단위 테스트**
+    - [ ] 결제 항목을 생성하면 상태는 PENDING로 초기화된다.
+    - [ ] 결제 항목은 결제가 완료되면 상태가 COMPLETED로 변경된다.
+    - [ ] 결제 항목은 결제가 실패하면 상태가 FAILED로 변경된다.
+    - [ ] 결제 항목은 정상적으로 생성되면 결제 ID, 주문 항목 ID, 금액이 올바르게 설정된다.
+     */
+    @DisplayName("PaymentItemEntity를 생성할 때, ")
+    @Nested
+    inner class Create {
+        @DisplayName("결제 항목을 생성하면 상태는 PENDING로 초기화된다.")
+        @Test
+        fun createPaymentItemEntityWithPendingStatus() {
+            // arrange
+            val paymentItem = PaymentItemEntity(
+                1L,
+                1L,
+                Price(1000L),
+            )
+
+            // assert
+            Assertions.assertThat(paymentItem.status).isEqualTo(PaymentItemEntity.PaymentItemStatusType.PENDING)
+        }
+
+        @DisplayName("결제 항목은 결제가 완료되면 상태가 COMPLETED로 변경된다.")
+        @Test
+        fun completePaymentItemEntity() {
+            // arrange
+            val paymentItem = PaymentItemEntity(
+                1L,
+                1L,
+                Price(1000L),
+            )
+
+            // act
+            paymentItem.complete()
+
+            // assert
+            assertThat(paymentItem.status).isEqualTo(PaymentItemEntity.PaymentItemStatusType.COMPLETED)
+        }
+
+        @DisplayName("결제 항목은 결제가 실패하면 상태가 FAILED로 변경된다.")
+        @Test
+        fun failPaymentItemEntity() {
+            // arrange
+            val paymentItem = PaymentItemEntity(
+                1L,
+                1L,
+                Price(1000L),
+            )
+
+            // act
+            paymentItem.fail()
+
+            // assert
+            assertThat(paymentItem.status).isEqualTo(PaymentItemEntity.PaymentItemStatusType.FAILED)
+        }
+
+        @DisplayName("결제 항목은 정상적으로 생성되면 결제 ID, 주문 항목 ID, 금액이 올바르게 설정된다.")
+        @Test
+        fun createPaymentItemEntityWithCorrectValues() {
+            // arrange
+            val paymentId = 1L
+            val orderItemId = 1L
+            val amount = Price(1000L)
+
+            // act
+            val paymentItem = PaymentItemEntity(
+                paymentId,
+                orderItemId,
+                amount,
+            )
+
+            // assert
+            assertThat(paymentItem.paymentId).isEqualTo(paymentId)
+            assertThat(paymentItem.orderItemId).isEqualTo(orderItemId)
+            assertThat(paymentItem.amount).isEqualTo(amount)
+        }
+    }
+
+}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/payment/vo/PaymentItemsTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/payment/vo/PaymentItemsTest.kt
@@ -1,0 +1,49 @@
+package com.loopers.domain.payment.vo
+
+import com.loopers.domain.payment.PaymentItemEntity
+import com.loopers.domain.vo.Price
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class PaymentItemsTest {
+    /*
+    **🧱 단위 테스트**
+    - [ ] 결제 항목 목록이 비어있으면 예외를 던진다.
+    - [ ] 결제 항목 목록은 총 금액을 계산할 수 있다.
+     */
+    @DisplayName("PaymentItems를 생성할 때, ")
+    @Nested
+    inner class Create {
+        @DisplayName("결제 항목 목록이 비어있으면 예외를 던진다.")
+        @Test
+        fun failWhenItemsIsEmpty() {
+            // arrange
+            val items = emptyList<PaymentItemEntity>()
+
+            // act
+            val exception = assertThrows<IllegalArgumentException> {
+                PaymentItems(items)
+            }
+
+            // assert
+            assertThat(exception.message).isEqualTo("주문 항목 목록은 비어있을 수 없습니다.")
+        }
+
+        @DisplayName("결제 항목 목록은 총 금액을 계산할 수 있다.")
+        @Test
+        fun calculateTotalAmount() {
+            // arrange
+            val paymentItem1 = PaymentItemEntity(1L, 1L, Price(1000L))
+            val paymentItem2 = PaymentItemEntity(2L, 2L, Price(2000L))
+
+            // act
+            val paymentItems = PaymentItems(listOf(paymentItem1, paymentItem2))
+
+            // assert
+            assertThat(paymentItems.totalAmount()).isEqualTo(Price(3000L))
+        }
+    }
+}


### PR DESCRIPTION
결제 항목 단위 테스트 작성

* 결제 항목을 생성하면 상태는 PENDING로 초기화된다.
* 결제 항목은 결제가 완료되면 상태가 COMPLETED로 변경된다.
* 결제 항목은 결제가 실패하면 상태가 FAILED로 변경된다.
* 결제 항목은 정상적으로 생성되면 결제 ID, 주문 항목 ID, 금액이 올바르게 설정된다.

결제 항목 목록 단위 테스트 작성

* 결제 항목 목록이 비어있으면 예외를 던진다.
* 결제 항목 목록은 총 금액을 계산할 수 있다.

결제 단위 테스트 작성

* 결제 정보를 생성하면 결제 금액과 결제 항목의 총 금액은 일치해야 한다.
* 결제 정볼르 생성하면 상태는 PENDING로 초기화된다.
* 결제 완료 처리 시 상태는 COMPLETED로 변경된다.
* 결제 실패 처리 시 상태는 FAILED로 변경된다.
