### PR TITLE
8주차 과제 구현 : Hello, Kafka!

### DIFF
--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductEventPublisher.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductEventPublisher.kt
@@ -1,7 +1,10 @@
 package com.loopers.domain.product
 
 import com.loopers.event.payload.product.ProductChangedEvent
+import com.loopers.event.payload.product.ProductViewedEvent
 
 interface ProductEventPublisher {
+    fun publish(productViewedEvent: ProductViewedEvent)
+
     fun publish(productChangedEvent: ProductChangedEvent)
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductEventPublisher.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/ProductEventPublisher.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.product
+
+import com.loopers.event.payload.product.ProductChangedEvent
+
+interface ProductEventPublisher {
+    fun publish(productChangedEvent: ProductChangedEvent)
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/productlike/ProductLikeEventPublisher.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/productlike/ProductLikeEventPublisher.kt
@@ -1,10 +1,10 @@
 package com.loopers.domain.productlike
 
-import com.loopers.event.payload.productlike.ProductLikeEvent
-import com.loopers.event.payload.productlike.ProductUnlikeEvent
+import com.loopers.event.payload.productlike.ProductLikedEvent
+import com.loopers.event.payload.productlike.ProductUnlikedEvent
 
 interface ProductLikeEventPublisher {
-    fun publish(productLikeEvent: ProductLikeEvent)
+    fun publish(productLikedEvent: ProductLikedEvent)
 
-    fun publish(productUnlikeEvent: ProductUnlikeEvent)
+    fun publish(productUnlikedEvent: ProductUnlikedEvent)
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/productlike/ProductLikeEventPublisher.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/productlike/ProductLikeEventPublisher.kt
@@ -1,0 +1,10 @@
+package com.loopers.domain.productlike
+
+import com.loopers.event.payload.productlike.ProductLikeEvent
+import com.loopers.event.payload.productlike.ProductUnlikeEvent
+
+interface ProductLikeEventPublisher {
+    fun publish(productLikeEvent: ProductLikeEvent)
+
+    fun publish(productUnlikeEvent: ProductUnlikeEvent)
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/productlike/ProductLikeService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/productlike/ProductLikeService.kt
@@ -1,7 +1,7 @@
 package com.loopers.domain.productlike
 
-import com.loopers.event.payload.productlike.ProductLikeEvent
-import com.loopers.event.payload.productlike.ProductUnlikeEvent
+import com.loopers.event.payload.productlike.ProductLikedEvent
+import com.loopers.event.payload.productlike.ProductUnlikedEvent
 import com.loopers.event.publisher.EventPublisher
 import com.loopers.support.cache.CacheKey
 import com.loopers.support.cache.CacheNames
@@ -49,7 +49,7 @@ class ProductLikeService(
         if (productLikeRepository.existsByUserIdAndProductId(command.userId, command.productId)) return
 
         productLikeRepository.create(command.toEntity()).let { created ->
-            eventPublisher.publish(ProductLikeEvent(created.productId))
+            eventPublisher.publish(ProductLikedEvent(created.productId))
         }
     }
 
@@ -61,7 +61,7 @@ class ProductLikeService(
             productLikeRepository.deleteByUserIdAndProductId(command.userId, command.productId)
         if (deleteCount == 0) return
 
-        eventPublisher.publish(ProductUnlikeEvent(command.productId))
+        eventPublisher.publish(ProductUnlikedEvent(command.productId))
     }
 
     @Transactional(readOnly = true)

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/productlike/ProductLikeService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/productlike/ProductLikeService.kt
@@ -81,7 +81,7 @@ class ProductLikeService(
         // 캐시 저장
         productLikeCount?.let {
             log.info("[Cache Miss] ProductLikeCount: $it")
-            cacheRepository.set(CacheKey(CacheNames.PRODUCT_DETAIL_V1, productId.toString()), it)
+            cacheRepository.set(CacheKey(CacheNames.PRODUCT_LIKE_COUNT_V1, productId.toString()), it)
         }
         return productLikeCount
     }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/productlike/ProductLikeService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/productlike/ProductLikeService.kt
@@ -3,6 +3,10 @@ package com.loopers.domain.productlike
 import com.loopers.event.payload.productlike.ProductLikeEvent
 import com.loopers.event.payload.productlike.ProductUnlikeEvent
 import com.loopers.event.publisher.EventPublisher
+import com.loopers.support.cache.CacheKey
+import com.loopers.support.cache.CacheNames
+import com.loopers.support.cache.CacheRepository
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -11,7 +15,11 @@ class ProductLikeService(
     private val productLikeRepository: ProductLikeRepository,
     private val productLikeCountRepository: ProductLikeCountRepository,
     private val eventPublisher: EventPublisher,
+    private val cacheRepository: CacheRepository,
 ) {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
     @Transactional
     fun like(command: ProductLikeCommand.Like) {
         if (productLikeRepository.existsByUserIdAndProductId(command.userId, command.productId)) return
@@ -58,7 +66,24 @@ class ProductLikeService(
 
     @Transactional(readOnly = true)
     fun getProductLikeCount(productId: Long): ProductLikeCountEntity? {
-        return productLikeCountRepository.findByProductId(productId)
+        val cache = cacheRepository.get(
+            CacheKey(CacheNames.PRODUCT_LIKE_COUNT_V1, productId.toString()),
+            ProductLikeCountEntity::class.java,
+        )
+        // 캐시 존재
+        cache?.let {
+            log.info("[Cache Hit] ProductLikeCount: $cache")
+            return it
+        }
+
+        val productLikeCount = productLikeCountRepository.findByProductId(productId)
+
+        // 캐시 저장
+        productLikeCount?.let {
+            log.info("[Cache Miss] ProductLikeCount: $it")
+            cacheRepository.set(CacheKey(CacheNames.PRODUCT_DETAIL_V1, productId.toString()), it)
+        }
+        return productLikeCount
     }
 
     @Transactional(readOnly = true)

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/stock/StockEntity.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/stock/StockEntity.kt
@@ -26,4 +26,8 @@ class StockEntity(
         require(!isQuantityLessThan(quantity)) { "차감할 재고 수량이 없습니다." }
         this.quantity -= quantity
     }
+
+    fun isSoldOut(): Boolean {
+        return quantity == 0
+    }
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/stock/StockEventPublisher.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/stock/StockEventPublisher.kt
@@ -1,7 +1,10 @@
 package com.loopers.domain.stock
 
 import com.loopers.event.payload.stock.StockAdjustedEvent
+import com.loopers.event.payload.stock.StockSoldOutEvent
 
 interface StockEventPublisher {
+    fun publish(stockSoldOutEvent: StockSoldOutEvent)
+
     fun publish(stockAdjustedEvent: StockAdjustedEvent)
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/stock/StockEventPublisher.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/stock/StockEventPublisher.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.stock
+
+import com.loopers.event.payload.stock.StockAdjustedEvent
+
+interface StockEventPublisher {
+    fun publish(stockAdjustedEvent: StockAdjustedEvent)
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductEventKafkaPublisher.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductEventKafkaPublisher.kt
@@ -1,0 +1,23 @@
+package com.loopers.infrastructure.product
+
+import com.loopers.domain.product.ProductEventPublisher
+import com.loopers.event.Event
+import com.loopers.event.EventType
+import com.loopers.event.payload.product.ProductChangedEvent
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class ProductEventKafkaPublisher(
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+) : ProductEventPublisher {
+    override fun publish(productChangedEvent: ProductChangedEvent) {
+        val event = Event(
+            UUID.randomUUID().toString(),
+            EventType.PRODUCT_CHANGED,
+            productChangedEvent,
+        )
+        kafkaTemplate.send(EventType.Topic.PRODUCT_CHANGED, event.toJson())
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductEventKafkaPublisher.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductEventKafkaPublisher.kt
@@ -3,21 +3,54 @@ package com.loopers.infrastructure.product
 import com.loopers.domain.product.ProductEventPublisher
 import com.loopers.event.Event
 import com.loopers.event.EventType
+import com.loopers.event.EventType.Topic
 import com.loopers.event.payload.product.ProductChangedEvent
+import org.slf4j.LoggerFactory
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Component
 import java.util.UUID
 
 @Component
 class ProductEventKafkaPublisher(
-    private val kafkaTemplate: KafkaTemplate<String, String>,
+    private val kafkaTemplate: KafkaTemplate<Any, Any>,
 ) : ProductEventPublisher {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
     override fun publish(productChangedEvent: ProductChangedEvent) {
+        log.info("[ProductEventKafkaPublisher.publish] productChangedEvent: $productChangedEvent")
         val event = Event(
             UUID.randomUUID().toString(),
             EventType.PRODUCT_CHANGED,
             productChangedEvent,
         )
-        kafkaTemplate.send(EventType.Topic.PRODUCT_CHANGED, event.toJson())
+        kafkaTemplate.send(Topic.PRODUCT_V1_CHANGED, productChangedEvent.productId.toString(), event.toJson())
+            .whenComplete { result, ex ->
+                if (ex == null) {
+                    val meta = result.recordMetadata
+                    log.info(
+                        "success to send message | topic={}, partition={}, offset={}",
+                        meta.topic(),
+                        meta.partition(),
+                        meta.offset(),
+                    )
+                } else {
+                    log.error(
+                        "fail to send message | topic= {}, partition= {}, offset= {}, ex= {}",
+                        result?.recordMetadata?.topic(),
+                        result?.recordMetadata?.partition(),
+                        result?.recordMetadata?.offset(),
+                        ex.message,
+                        ex,
+                    )
+
+                    // DLT 토픽 발행
+                    kafkaTemplate.send(
+                        Topic.PRODUCT_V1_CHANGED_DLT,
+                        productChangedEvent.productId.toString(),
+                        event.toJson(),
+                    )
+                }
+            }
     }
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductEventKafkaPublisher.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/ProductEventKafkaPublisher.kt
@@ -5,6 +5,7 @@ import com.loopers.event.Event
 import com.loopers.event.EventType
 import com.loopers.event.EventType.Topic
 import com.loopers.event.payload.product.ProductChangedEvent
+import com.loopers.event.payload.product.ProductViewedEvent
 import org.slf4j.LoggerFactory
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Component
@@ -16,6 +17,43 @@ class ProductEventKafkaPublisher(
 ) : ProductEventPublisher {
 
     private val log = LoggerFactory.getLogger(this::class.java)
+
+    override fun publish(productViewedEvent: ProductViewedEvent) {
+        log.info("[ProductEventKafkaPublisher.publish] productViewedEvent: $productViewedEvent")
+        val event = Event(
+            UUID.randomUUID().toString(),
+            EventType.PRODUCT_VIEWED,
+            productViewedEvent,
+        )
+        kafkaTemplate.send(Topic.PRODUCT_V1_VIEWED, productViewedEvent.productId.toString(), event.toJson())
+            .whenComplete { result, ex ->
+                if (ex == null) {
+                    val meta = result.recordMetadata
+                    log.info(
+                        "success to send message | topic={}, partition={}, offset={}",
+                        meta.topic(),
+                        meta.partition(),
+                        meta.offset(),
+                    )
+                } else {
+                    log.error(
+                        "fail to send message | topic= {}, partition= {}, offset= {}, ex= {}",
+                        result?.recordMetadata?.topic(),
+                        result?.recordMetadata?.partition(),
+                        result?.recordMetadata?.offset(),
+                        ex.message,
+                        ex,
+                    )
+
+                    // DLT 토픽 발행
+                    kafkaTemplate.send(
+                        Topic.PRODUCT_V1_VIEWED_DLT,
+                        productViewedEvent.productId.toString(),
+                        event.toJson(),
+                    )
+                }
+            }
+    }
 
     override fun publish(productChangedEvent: ProductChangedEvent) {
         log.info("[ProductEventKafkaPublisher.publish] productChangedEvent: $productChangedEvent")

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/productlike/ProductLikeEventKafkaPublisher.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/productlike/ProductLikeEventKafkaPublisher.kt
@@ -1,0 +1,40 @@
+package com.loopers.infrastructure.productlike
+
+import com.loopers.domain.productlike.ProductLikeEventPublisher
+import com.loopers.event.Event
+import com.loopers.event.EventType
+import com.loopers.event.payload.productlike.ProductLikeChangedEvent
+import com.loopers.event.payload.productlike.ProductLikeEvent
+import com.loopers.event.payload.productlike.ProductUnlikeEvent
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class ProductLikeEventKafkaPublisher(
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+) : ProductLikeEventPublisher {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    override fun publish(productLikeEvent: ProductLikeEvent) {
+        log.info("[ProductLikeEventKafkaPublisher.publish] productLikeEvent: $productLikeEvent")
+        val event = Event(
+            UUID.randomUUID().toString(),
+            EventType.PRODUCT_LIKED,
+            ProductLikeChangedEvent(productLikeEvent.productId),
+        )
+        kafkaTemplate.send(EventType.Topic.PRODUCT_LIKE_CHANGED, event.toJson())
+    }
+
+    override fun publish(productUnlikeEvent: ProductUnlikeEvent) {
+        log.info("[ProductLikeEventKafkaPublisher.publish] productUnlikeEvent: $productUnlikeEvent")
+        val event = Event(
+            UUID.randomUUID().toString(),
+            EventType.PRODUCT_UNLIKED,
+            ProductLikeChangedEvent(productUnlikeEvent.productId),
+        )
+        kafkaTemplate.send(EventType.Topic.PRODUCT_LIKE_CHANGED, event.toJson())
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/stock/StockAdjustedEventKafkaPublisher.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/stock/StockAdjustedEventKafkaPublisher.kt
@@ -1,0 +1,28 @@
+package com.loopers.infrastructure.stock
+
+import com.loopers.domain.stock.StockEventPublisher
+import com.loopers.event.Event
+import com.loopers.event.EventType
+import com.loopers.event.payload.stock.StockAdjustedEvent
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class StockAdjustedEventKafkaPublisher(
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+) : StockEventPublisher {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    override fun publish(stockAdjustedEvent: StockAdjustedEvent) {
+        log.info("[StockAdjustedEventKafkaPublisher.publish] stockAdjustedEvent: $stockAdjustedEvent")
+        val event = Event(
+            UUID.randomUUID().toString(),
+            EventType.PRODUCT_STOCK_ADJUSTED,
+            stockAdjustedEvent,
+        )
+        kafkaTemplate.send(EventType.Topic.PRODUCT_STOCK_ADJUSTED, event.toJson())
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/stock/StockAdjustedEventKafkaPublisher.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/stock/StockAdjustedEventKafkaPublisher.kt
@@ -3,6 +3,7 @@ package com.loopers.infrastructure.stock
 import com.loopers.domain.stock.StockEventPublisher
 import com.loopers.event.Event
 import com.loopers.event.EventType
+import com.loopers.event.EventType.Topic
 import com.loopers.event.payload.stock.StockAdjustedEvent
 import org.slf4j.LoggerFactory
 import org.springframework.kafka.core.KafkaTemplate
@@ -11,7 +12,7 @@ import java.util.UUID
 
 @Component
 class StockAdjustedEventKafkaPublisher(
-    private val kafkaTemplate: KafkaTemplate<String, String>,
+    private val kafkaTemplate: KafkaTemplate<Any, Any>,
 ) : StockEventPublisher {
 
     private val log = LoggerFactory.getLogger(this::class.java)
@@ -23,6 +24,33 @@ class StockAdjustedEventKafkaPublisher(
             EventType.PRODUCT_STOCK_ADJUSTED,
             stockAdjustedEvent,
         )
-        kafkaTemplate.send(EventType.Topic.PRODUCT_STOCK_ADJUSTED, event.toJson())
+        kafkaTemplate.send(Topic.PRODUCT_V1_STOCK_ADJUSTED, stockAdjustedEvent.productId.toString(), event.toJson())
+            .whenComplete { result, ex ->
+                if (ex == null) {
+                    val meta = result.recordMetadata
+                    log.info(
+                        "success to send message | topic={}, partition={}, offset={}",
+                        meta.topic(),
+                        meta.partition(),
+                        meta.offset(),
+                    )
+                } else {
+                    log.error(
+                        "fail to send message | topic= {}, partition= {}, offset= {}, ex= {}",
+                        result?.recordMetadata?.topic(),
+                        result?.recordMetadata?.partition(),
+                        result?.recordMetadata?.offset(),
+                        ex.message,
+                        ex,
+                    )
+
+                    // DLT 토픽 발행
+                    kafkaTemplate.send(
+                        Topic.PRODUCT_V1_STOCK_ADJUSTED_DLT,
+                        stockAdjustedEvent.productId.toString(),
+                        event.toJson(),
+                    )
+                }
+            }
     }
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/stock/StockEventKafkaPublisher.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/stock/StockEventKafkaPublisher.kt
@@ -5,17 +5,55 @@ import com.loopers.event.Event
 import com.loopers.event.EventType
 import com.loopers.event.EventType.Topic
 import com.loopers.event.payload.stock.StockAdjustedEvent
+import com.loopers.event.payload.stock.StockSoldOutEvent
 import org.slf4j.LoggerFactory
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Component
 import java.util.UUID
 
 @Component
-class StockAdjustedEventKafkaPublisher(
+class StockEventKafkaPublisher(
     private val kafkaTemplate: KafkaTemplate<Any, Any>,
 ) : StockEventPublisher {
 
     private val log = LoggerFactory.getLogger(this::class.java)
+
+    override fun publish(stockSoldOutEvent: StockSoldOutEvent) {
+        log.info("[StockSoldOutEventKafkaPublisher.publish] stockSoldOutEvent: $stockSoldOutEvent")
+        val event = Event(
+            UUID.randomUUID().toString(),
+            EventType.PRODUCT_STOCK_SOLD_OUT,
+            stockSoldOutEvent,
+        )
+        kafkaTemplate.send(Topic.PRODUCT_V1_STOCK_SOLD_OUT, stockSoldOutEvent.productId.toString(), event.toJson())
+            .whenComplete { result, ex ->
+                if (ex == null) {
+                    val meta = result.recordMetadata
+                    log.info(
+                        "success to send message | topic={}, partition={}, offset={}",
+                        meta.topic(),
+                        meta.partition(),
+                        meta.offset(),
+                    )
+                } else {
+                    log.error(
+                        "fail to send message | topic= {}, partition= {}, offset= {}, ex= {}",
+                        result?.recordMetadata?.topic(),
+                        result?.recordMetadata?.partition(),
+                        result?.recordMetadata?.offset(),
+                        ex.message,
+                        ex,
+                    )
+
+                    // DLT 토픽 발행
+                    kafkaTemplate.send(
+                        Topic.PRODUCT_V1_STOCK_SOLD_OUT_DLT,
+                        stockSoldOutEvent.productId.toString(),
+                        event.toJson(),
+                    )
+                }
+            }
+    }
 
     override fun publish(stockAdjustedEvent: StockAdjustedEvent) {
         log.info("[StockAdjustedEventKafkaPublisher.publish] stockAdjustedEvent: $stockAdjustedEvent")

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/listener/order/OrderEventListener.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/listener/order/OrderEventListener.kt
@@ -11,6 +11,7 @@ import com.loopers.event.payload.payment.PaymentCompletedEvent
 import com.loopers.event.payload.payment.PaymentFailedEvent
 import com.loopers.event.payload.payment.PaymentFailedSuccessEvent
 import com.loopers.event.payload.stock.StockAdjustedEvent
+import com.loopers.event.payload.stock.StockSoldOutEvent
 import com.loopers.event.publisher.EventPublisher
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -78,6 +79,9 @@ class OrderEventListener(
         order.orderItems.toProductQuantityMap().forEach { productQuantity ->
             stockEventPublisher.publish(StockAdjustedEvent(productQuantity.key, productQuantity.value))
         }
+        val stocks = stockService.getStocksByProductIds(order.orderItems.toProductQuantityMap().map { it.key })
+        stocks.filter { it.isSoldOut() }
+            .forEach { stockEventPublisher.publish(StockSoldOutEvent(it.productId)) }
     }
 
     /*

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/listener/order/OrderEventListener.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/listener/order/OrderEventListener.kt
@@ -76,13 +76,13 @@ class OrderEventListener(
         val order = orderService.findWithItemsByOrderKey(event.orderKey)
             ?: throw IllegalStateException("주문 정보를 찾을 수 없습니다. orderKey: ${event.orderKey}")
         order.orderItems.toProductQuantityMap().forEach { productQuantity ->
-            stockEventPublisher.publish(StockAdjustedEvent(productQuantity.key))
+            stockEventPublisher.publish(StockAdjustedEvent(productQuantity.key, productQuantity.value))
         }
     }
 
     /*
     주문 완료 롤백
-    */
+     */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
     fun handle(event: OrderCompletedEvent) {

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/listener/product/ProductEventListener.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/listener/product/ProductEventListener.kt
@@ -19,7 +19,8 @@ class ProductEventListener(
 
     @EventListener
     fun handle(event: ProductViewedEvent) {
-        log.info("상품 조회 이벤트 수신: $event")
+        log.info("[ProductEventListener.handle] event: $event")
+        productEventPublisher.publish(event)
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/listener/product/ProductEventListener.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/listener/product/ProductEventListener.kt
@@ -1,17 +1,31 @@
 package com.loopers.interfaces.listener.product
 
+import com.loopers.domain.product.ProductEventPublisher
+import com.loopers.event.payload.product.ProductChangedEvent
 import com.loopers.event.payload.product.ProductViewedEvent
 import org.slf4j.LoggerFactory
 import org.springframework.context.event.EventListener
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
 
 @Component
-class ProductEventListener {
+class ProductEventListener(
+    private val productEventPublisher: ProductEventPublisher,
+) {
 
     private val log = LoggerFactory.getLogger(this::class.java)
 
     @EventListener
     fun handle(event: ProductViewedEvent) {
         log.info("상품 조회 이벤트 수신: $event")
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    fun handleAfterEvent(event: ProductChangedEvent) {
+        log.info("[ProductEventListener.handleAfterEvent] event: $event")
+        productEventPublisher.publish(event)
     }
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/listener/productlike/ProductLikeEventListener.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/listener/productlike/ProductLikeEventListener.kt
@@ -1,6 +1,7 @@
 package com.loopers.interfaces.listener.productlike
 
 import com.loopers.domain.productlike.ProductLikeCountService
+import com.loopers.domain.productlike.ProductLikeEventPublisher
 import com.loopers.event.payload.productlike.ProductLikeEvent
 import com.loopers.event.payload.productlike.ProductUnlikeEvent
 import org.slf4j.LoggerFactory
@@ -12,6 +13,7 @@ import org.springframework.transaction.event.TransactionalEventListener
 @Component
 class ProductLikeEventListener(
     private val productLikeCountService: ProductLikeCountService,
+    private val productLikeEventPublisher: ProductLikeEventPublisher,
 ) {
 
     private val log = LoggerFactory.getLogger(this::class.java)
@@ -19,14 +21,29 @@ class ProductLikeEventListener(
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Async
     fun handle(event: ProductLikeEvent) {
-        log.info("상품 좋아요 이벤트 수신: $event")
+        log.info("[ProductLikeEventListener.handle] event: $event")
         productLikeCountService.increase(event.productId)
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Async
+    fun handleAfterEvent(event: ProductLikeEvent) {
+        log.info("[ProductLikeEventListener.handleAfterEvent] event: $event")
+        productLikeEventPublisher.publish(event)
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
     fun handle(event: ProductUnlikeEvent) {
-        log.info("상품 좋아요 취소 이벤트 수신: $event")
+        log.info("[ProductUnlikeEventListener.handle] event: $event")
         productLikeCountService.decrease(event.productId)
     }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    fun handleAfterEvent(event: ProductUnlikeEvent) {
+        log.info("[ProductUnlikeEventListener.handleAfterEvent] event: $event")
+        productLikeEventPublisher.publish(event)
+    }
+
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/listener/productlike/ProductLikeEventListener.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/listener/productlike/ProductLikeEventListener.kt
@@ -2,8 +2,8 @@ package com.loopers.interfaces.listener.productlike
 
 import com.loopers.domain.productlike.ProductLikeCountService
 import com.loopers.domain.productlike.ProductLikeEventPublisher
-import com.loopers.event.payload.productlike.ProductLikeEvent
-import com.loopers.event.payload.productlike.ProductUnlikeEvent
+import com.loopers.event.payload.productlike.ProductLikedEvent
+import com.loopers.event.payload.productlike.ProductUnlikedEvent
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
@@ -20,30 +20,29 @@ class ProductLikeEventListener(
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Async
-    fun handle(event: ProductLikeEvent) {
+    fun handle(event: ProductLikedEvent) {
         log.info("[ProductLikeEventListener.handle] event: $event")
         productLikeCountService.increase(event.productId)
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Async
-    fun handleAfterEvent(event: ProductLikeEvent) {
+    fun handleAfterEvent(event: ProductLikedEvent) {
         log.info("[ProductLikeEventListener.handleAfterEvent] event: $event")
         productLikeEventPublisher.publish(event)
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Async
-    fun handle(event: ProductUnlikeEvent) {
+    fun handle(event: ProductUnlikedEvent) {
         log.info("[ProductUnlikeEventListener.handle] event: $event")
         productLikeCountService.decrease(event.productId)
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Async
-    fun handleAfterEvent(event: ProductUnlikeEvent) {
+    fun handleAfterEvent(event: ProductUnlikedEvent) {
         log.info("[ProductUnlikeEventListener.handleAfterEvent] event: $event")
         productLikeEventPublisher.publish(event)
     }
-
 }

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -92,6 +92,7 @@ spring:
     import:
       - jpa.yml
       - redis.yml
+      - kafka.yml
       - logging.yml
       - monitoring.yml
 

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/brand/BrandServiceIntegrationTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/brand/BrandServiceIntegrationTest.kt
@@ -14,8 +14,15 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.SendResult
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.util.concurrent.CompletableFuture
 
 @SpringBootTest
 class BrandServiceIntegrationTest @Autowired constructor(
@@ -24,6 +31,9 @@ class BrandServiceIntegrationTest @Autowired constructor(
     private val databaseCleanUp: DatabaseCleanUp,
     private val redisCleanUp: RedisCleanUp,
 ) {
+
+    @MockitoBean
+    lateinit var kafkaTemplate: KafkaTemplate<Any, Any>
 
     @AfterEach
     fun tearDown() {
@@ -47,6 +57,10 @@ class BrandServiceIntegrationTest @Autowired constructor(
                 "브랜드A",
             )
             brandService.createBrand(brandCreateCommand)
+
+            // kafka mock
+            val future = CompletableFuture.completedFuture(mock<SendResult<Any, Any>>())
+            whenever(kafkaTemplate.send(any(), any(), any())).thenReturn(future)
 
             // act
             val exception = assertThrows<CoreException> {
@@ -94,6 +108,10 @@ class BrandServiceIntegrationTest @Autowired constructor(
             // arrange
             val nonExistentBrandId = 999L
             assertThat(brandJpaRepository.findAll()).isEmpty()
+
+            // kafka mock
+            val future = CompletableFuture.completedFuture(mock<SendResult<Any, Any>>())
+            whenever(kafkaTemplate.send(any(), any(), any())).thenReturn(future)
 
             // act
             val brand = brandService.findBrandBy(nonExistentBrandId)

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/brand/query/BrandQueryServiceTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/brand/query/BrandQueryServiceTest.kt
@@ -13,10 +13,17 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.SendResult
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.util.concurrent.CompletableFuture
 
 @SpringBootTest
 class BrandQueryServiceTest @Autowired constructor(
@@ -24,6 +31,9 @@ class BrandQueryServiceTest @Autowired constructor(
     private val brandJpaRepository: BrandJpaRepository,
     private val databaseCleanUp: DatabaseCleanUp,
 ) {
+
+    @MockitoBean
+    lateinit var kafkaTemplate: KafkaTemplate<Any, Any>
 
     @AfterEach
     fun tearDown() {
@@ -122,6 +132,10 @@ class BrandQueryServiceTest @Autowired constructor(
             brandJpaRepository.save(aBrand().name("브랜드A").build())
             brandJpaRepository.save(aBrand().name("브랜드B").build())
 
+            // kafka mock
+            val future = CompletableFuture.completedFuture(mock<SendResult<Any, Any>>())
+            whenever(kafkaTemplate.send(any(), any(), any())).thenReturn(future)
+
             // act
             val condition = BrandSearchCondition(name = "브랜드C")
             val pageRequest = PageRequest.of(0, 10)
@@ -163,6 +177,10 @@ class BrandQueryServiceTest @Autowired constructor(
             // arrange
             val createdBrand1 = brandJpaRepository.save(aBrand().name("브랜드A").build())
             val createdBrand2 = brandJpaRepository.save(aBrand().name("브랜드B").build())
+
+            // kafka mock
+            val future = CompletableFuture.completedFuture(mock<SendResult<Any, Any>>())
+            whenever(kafkaTemplate.send(any(), any(), any())).thenReturn(future)
 
             // act
             val condition = BrandSearchCondition()

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/point/PointServiceIntegrationTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/point/PointServiceIntegrationTest.kt
@@ -16,8 +16,15 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.SendResult
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.util.concurrent.CompletableFuture
 
 @SpringBootTest
 class PointServiceIntegrationTest @Autowired constructor(
@@ -26,6 +33,9 @@ class PointServiceIntegrationTest @Autowired constructor(
     private val pointJpaRepository: PointJpaRepository,
     private val databaseCleanUp: DatabaseCleanUp,
 ) {
+
+    @MockitoBean
+    lateinit var kafkaTemplate: KafkaTemplate<Any, Any>
 
     @AfterEach
     fun tearDown() {
@@ -90,6 +100,10 @@ class PointServiceIntegrationTest @Autowired constructor(
                 nonExistentUserId,
                 Point(chargeAmount),
             )
+
+            // kafka mock
+            val future = CompletableFuture.completedFuture(mock<SendResult<Any, Any>>())
+            whenever(kafkaTemplate.send(any(), any(), any())).thenReturn(future)
 
             // act
             val exception = assertThrows<CoreException> {

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/product/ProductServiceIntegrationTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/product/ProductServiceIntegrationTest.kt
@@ -16,8 +16,15 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.SendResult
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.util.concurrent.CompletableFuture
 import kotlin.test.Test
 
 @SpringBootTest
@@ -28,6 +35,9 @@ class ProductServiceIntegrationTest @Autowired constructor(
     private val databaseCleanUp: DatabaseCleanUp,
     private val redisCleanUp: RedisCleanUp,
 ) {
+
+    @MockitoBean
+    lateinit var kafkaTemplate: KafkaTemplate<Any, Any>
 
     @AfterEach
     fun tearDown() {
@@ -137,6 +147,10 @@ class ProductServiceIntegrationTest @Autowired constructor(
         fun returnsNull_whenProductDoesNotExist() {
             // arrange
             val nonExistentProductId = 999L
+
+            // kafka mock
+            val future = CompletableFuture.completedFuture(mock<SendResult<Any, Any>>())
+            whenever(kafkaTemplate.send(any(), any(), any())).thenReturn(future)
 
             // act
             val product = productService.findProductBy(nonExistentProductId)

--- a/apps/commerce-api/src/test/kotlin/com/loopers/interfaces/api/brand/BrandV1ApiE2ETest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/interfaces/api/brand/BrandV1ApiE2ETest.kt
@@ -13,6 +13,9 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.client.TestRestTemplate
@@ -21,6 +24,10 @@ import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.SendResult
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.util.concurrent.CompletableFuture
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class BrandV1ApiE2ETest @Autowired constructor(
@@ -29,6 +36,9 @@ class BrandV1ApiE2ETest @Autowired constructor(
     private val userJpaRepository: UserJpaRepository,
     private val databaseCleanUp: DatabaseCleanUp,
 ) {
+
+    @MockitoBean
+    lateinit var kafkaTemplate: KafkaTemplate<Any, Any>
 
     @AfterEach
     fun tearDown() {
@@ -62,6 +72,10 @@ class BrandV1ApiE2ETest @Autowired constructor(
             httpHeaders.set("X-USER-ID", nonExistentUsername)
             val httpEntity = HttpEntity(createRequest, httpHeaders)
 
+            // kafka mock
+            val future = CompletableFuture.completedFuture(mock<SendResult<Any, Any>>())
+            whenever(kafkaTemplate.send(any(), any(), any())).thenReturn(future)
+
             // act
             val response = testRestTemplate.exchange(
                 ENDPOINT_BRAND,
@@ -85,6 +99,10 @@ class BrandV1ApiE2ETest @Autowired constructor(
             val httpHeaders = HttpHeaders()
             httpHeaders.set("X-USER-ID", createdUser.username)
             val httpEntity = HttpEntity<Any>(createRequest, httpHeaders)
+
+            // kafka mock
+            val future = CompletableFuture.completedFuture(mock<SendResult<Any, Any>>())
+            whenever(kafkaTemplate.send(any(), any(), any())).thenReturn(future)
 
             // act
             val responseType = object : ParameterizedTypeReference<ApiResponse<BrandV1Dto.BrandResponse>>() {}
@@ -110,6 +128,10 @@ class BrandV1ApiE2ETest @Autowired constructor(
             val httpHeaders = HttpHeaders()
             httpHeaders.set("X-USER-ID", createdUser.username)
             val httpEntity = HttpEntity<Any>(createRequest, httpHeaders)
+
+            // kafka mock
+            val future = CompletableFuture.completedFuture(mock<SendResult<Any, Any>>())
+            whenever(kafkaTemplate.send(any(), any(), any())).thenReturn(future)
 
             // act
             val response = testRestTemplate.exchange(

--- a/apps/commerce-api/src/test/kotlin/com/loopers/interfaces/api/order/OrderV1ApiE2ETest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/interfaces/api/order/OrderV1ApiE2ETest.kt
@@ -21,6 +21,9 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.client.TestRestTemplate
@@ -29,6 +32,10 @@ import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.SendResult
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.util.concurrent.CompletableFuture
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class OrderV1ApiE2ETest @Autowired constructor(
@@ -41,6 +48,9 @@ class OrderV1ApiE2ETest @Autowired constructor(
     private val databaseCleanUp: DatabaseCleanUp,
     private val redisCleanUp: RedisCleanUp,
 ) {
+
+    @MockitoBean
+    lateinit var kafkaTemplate: KafkaTemplate<Any, Any>
 
     @AfterEach
     fun tearDown() {
@@ -89,6 +99,10 @@ class OrderV1ApiE2ETest @Autowired constructor(
             val httpHeaders = HttpHeaders().apply { set("X-USER-ID", createdUser.username) }
             val httpEntity = HttpEntity<Any>(Unit, httpHeaders)
 
+            // kafka mock
+            val future = CompletableFuture.completedFuture(mock<SendResult<Any, Any>>())
+            whenever(kafkaTemplate.send(any(), any(), any())).thenReturn(future)
+
             // act
             val responseType = object : ParameterizedTypeReference<ApiResponse<OrderV1Dto.OrderResponse>>() {}
             val response = testRestTemplate.exchange(requestUrl, HttpMethod.GET, httpEntity, responseType)
@@ -106,6 +120,10 @@ class OrderV1ApiE2ETest @Autowired constructor(
             val requestUrl = ENDPOINT_ORDER_GET(createdOrder.id)
             val httpHeaders = HttpHeaders().apply { set("X-USER-ID", createdUser.username) }
             val httpEntity = HttpEntity<Any>(Unit, httpHeaders)
+
+            // kafka mock
+            val future = CompletableFuture.completedFuture(mock<SendResult<Any, Any>>())
+            whenever(kafkaTemplate.send(any(), any(), any())).thenReturn(future)
 
             // act
             val responseType = object : ParameterizedTypeReference<ApiResponse<OrderV1Dto.OrderResponse>>() {}
@@ -191,6 +209,10 @@ class OrderV1ApiE2ETest @Autowired constructor(
             val requestUrl = ENDPOINT_ORDER
             val httpHeaders = HttpHeaders().apply { set("X-USER-ID", createdUser.username) }
             val httpEntity = HttpEntity<Any>(orderCreateRequest, httpHeaders)
+
+            // kafka mock
+            val future = CompletableFuture.completedFuture(mock<SendResult<Any, Any>>())
+            whenever(kafkaTemplate.send(any(), any(), any())).thenReturn(future)
 
             // act
             val responseType = object : ParameterizedTypeReference<ApiResponse<Long>>() {}

--- a/apps/commerce-api/src/test/kotlin/com/loopers/interfaces/api/product/ProductV1ApiE2ETest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/interfaces/api/product/ProductV1ApiE2ETest.kt
@@ -16,6 +16,9 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.client.TestRestTemplate
@@ -24,6 +27,10 @@ import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.SendResult
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.util.concurrent.CompletableFuture
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class ProductV1ApiE2ETest @Autowired constructor(
@@ -34,6 +41,9 @@ class ProductV1ApiE2ETest @Autowired constructor(
     private val databaseCleanUp: DatabaseCleanUp,
     private val redisCleanUp: RedisCleanUp,
 ) {
+
+    @MockitoBean
+    lateinit var kafkaTemplate: KafkaTemplate<Any, Any>
 
     @AfterEach
     fun tearDown() {
@@ -95,6 +105,10 @@ class ProductV1ApiE2ETest @Autowired constructor(
             val httpHeaders = HttpHeaders().apply { set("X-USER-ID", createdUser.username) }
             val httpEntity = HttpEntity<Any>(createRequest, httpHeaders)
 
+            // kafka mock
+            val future = CompletableFuture.completedFuture(mock<SendResult<Any, Any>>())
+            whenever(kafkaTemplate.send(any(), any(), any())).thenReturn(future)
+
             // act
             val responseType = object : ParameterizedTypeReference<ApiResponse<ProductV1Dto.ProductResultResponse>>() {}
             val response = testRestTemplate.exchange(ENDPOINT_PRODUCT, HttpMethod.POST, httpEntity, responseType)
@@ -126,6 +140,10 @@ class ProductV1ApiE2ETest @Autowired constructor(
             )
             val httpHeaders = HttpHeaders().apply { set("X-USER-ID", createdUser.username) }
             val httpEntity = HttpEntity<Any>(createRequest, httpHeaders)
+
+            // kafka mock
+            val future = CompletableFuture.completedFuture(mock<SendResult<Any, Any>>())
+            whenever(kafkaTemplate.send(any(), any(), any())).thenReturn(future)
 
             // act
             val responseType = object : ParameterizedTypeReference<ApiResponse<ProductV1Dto.ProductResultResponse>>() {}

--- a/apps/commerce-streamer/build.gradle.kts
+++ b/apps/commerce-streamer/build.gradle.kts
@@ -25,5 +25,4 @@ dependencies {
     testImplementation(testFixtures(project(":modules:jpa")))
     testImplementation(testFixtures(project(":modules:redis")))
     testImplementation(testFixtures(project(":modules:kafka")))
-
 }

--- a/apps/commerce-streamer/build.gradle.kts
+++ b/apps/commerce-streamer/build.gradle.kts
@@ -7,17 +7,11 @@ dependencies {
     implementation(project(":modules:jpa"))
     implementation(project(":modules:redis"))
     implementation(project(":modules:data-serializer"))
-    implementation(project(":modules:feign"))
-    implementation(project(":modules:retry"))
     implementation(project(":modules:event"))
     implementation(project(":modules:kafka"))
     implementation(project(":supports:jackson"))
     implementation(project(":supports:logging"))
     implementation(project(":supports:monitoring"))
-
-    // feign
-    api("org.springframework.cloud:spring-cloud-starter-openfeign")
-    api("org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j")
 
     // web
     implementation("org.springframework.boot:spring-boot-starter-web")
@@ -31,4 +25,5 @@ dependencies {
     testImplementation(testFixtures(project(":modules:jpa")))
     testImplementation(testFixtures(project(":modules:redis")))
     testImplementation(testFixtures(project(":modules:kafka")))
+
 }

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/CommerceStreamerApplication.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/CommerceStreamerApplication.kt
@@ -1,0 +1,19 @@
+package com.loopers
+
+import jakarta.annotation.PostConstruct
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class CommerceStreamerApplication {
+
+    @PostConstruct
+    fun started() {
+        // set timezone
+        java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Asia/Seoul"))
+    }
+}
+
+fun main(args: Array<String>) {
+    runApplication<CommerceStreamerApplication>(*args)
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/auditlog/AuditLog.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/auditlog/AuditLog.kt
@@ -1,0 +1,20 @@
+package com.loopers.domain.auditlog
+
+import com.loopers.domain.BaseEntity
+import com.loopers.event.EventType
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "event_log")
+class AuditLog(
+    val eventId: String,
+    @Enumerated(EnumType.STRING)
+    val eventType: EventType,
+    val topic: String,
+    val partitionNo: Int,
+    val offsetNo: Long,
+    val payload: String,
+) : BaseEntity()

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/auditlog/AuditLogCommand.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/auditlog/AuditLogCommand.kt
@@ -1,0 +1,25 @@
+package com.loopers.domain.auditlog
+
+import com.loopers.event.EventType
+
+class AuditLogCommand {
+    data class Create(
+        val eventId: String,
+        val eventType: EventType,
+        val topic: String,
+        val partitionNo: Int,
+        val offsetNo: Long,
+        val payload: String,
+    ) {
+        fun toEntity(): AuditLog {
+            return AuditLog(
+                eventId,
+                eventType,
+                topic,
+                partitionNo,
+                offsetNo,
+                payload,
+            )
+        }
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/auditlog/AuditLogRepository.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/auditlog/AuditLogRepository.kt
@@ -1,0 +1,5 @@
+package com.loopers.domain.auditlog
+
+interface AuditLogRepository {
+    fun save(auditLog: AuditLog)
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/auditlog/AuditLogService.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/auditlog/AuditLogService.kt
@@ -1,0 +1,17 @@
+package com.loopers.domain.auditlog
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class AuditLogService(
+    private val auditLogRepository: AuditLogRepository,
+) {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    fun saveAuditLog(command: AuditLogCommand.Create) {
+        log.info("[AuditLogService.saveAuditLog] command: $command")
+        auditLogRepository.save(command.toEntity())
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/CatalogEventHandler.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/CatalogEventHandler.kt
@@ -1,0 +1,10 @@
+package com.loopers.domain.catalog
+
+import com.loopers.event.EventType
+import com.loopers.event.payload.EventPayload
+
+interface CatalogEventHandler<T : EventPayload> {
+    fun handle(eventPayload: T)
+
+    fun supports(eventType: EventType): Boolean
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/CatalogEventHandlerFactory.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/CatalogEventHandlerFactory.kt
@@ -1,0 +1,15 @@
+package com.loopers.domain.catalog
+
+import com.loopers.event.Event
+import com.loopers.event.payload.EventPayload
+import org.springframework.stereotype.Component
+
+@Component
+class CatalogEventHandlerFactory(
+    private val handlers: List<CatalogEventHandler<EventPayload>>,
+) {
+    fun handle(event: Event<EventPayload>) {
+        handlers.find { it.supports(event.eventType) }?.handle(event.payload)
+            ?: throw IllegalStateException("해당 이벤트를 처리할 핸들러가 없습니다.")
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/CatalogEventHandlerFactory.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/CatalogEventHandlerFactory.kt
@@ -6,10 +6,13 @@ import org.springframework.stereotype.Component
 
 @Component
 class CatalogEventHandlerFactory(
-    private val handlers: List<CatalogEventHandler<EventPayload>>,
+    private val handlers: List<CatalogEventHandler<out EventPayload>>,
 ) {
-    fun handle(event: Event<EventPayload>) {
-        handlers.find { it.supports(event.eventType) }?.handle(event.payload)
+    @Suppress("UNCHECKED_CAST")
+    fun <T : EventPayload> handle(event: Event<T>) {
+        val handler = handlers.find { it.supports(event.eventType) }
+                as? CatalogEventHandler<T>
             ?: throw IllegalStateException("해당 이벤트를 처리할 핸들러가 없습니다.")
+        handler.handle(event.payload)
     }
 }

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/CatalogService.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/CatalogService.kt
@@ -1,0 +1,14 @@
+package com.loopers.domain.catalog
+
+import com.loopers.event.Event
+import com.loopers.event.payload.EventPayload
+import org.springframework.stereotype.Service
+
+@Service
+class CatalogService(
+    private val catalogEventHandlerFactory: CatalogEventHandlerFactory,
+) {
+    fun handleEvent(event: Event<EventPayload>) {
+        catalogEventHandlerFactory.handle(event)
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/handler/ProductChangedEventHandler.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/handler/ProductChangedEventHandler.kt
@@ -1,0 +1,27 @@
+package com.loopers.domain.catalog.handler
+
+import com.loopers.domain.catalog.CatalogEventHandler
+import com.loopers.event.EventType
+import com.loopers.event.payload.product.ProductChangedEvent
+import com.loopers.support.cache.CacheNames
+import com.loopers.support.cache.CacheRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class ProductChangedEventHandler(
+    private val cacheRepository: CacheRepository,
+) : CatalogEventHandler<ProductChangedEvent> {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    override fun handle(eventPayload: ProductChangedEvent) {
+        log.info("[ProductChangedEventHandler.handle] eventPayload: $eventPayload")
+        cacheRepository.evict(CacheNames.PRODUCT_DETAIL_V1 + eventPayload.productId)
+    }
+
+    override fun supports(eventType: EventType): Boolean {
+        return EventType.PRODUCT_CHANGED == eventType
+    }
+
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/handler/ProductChangedEventHandler.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/handler/ProductChangedEventHandler.kt
@@ -23,5 +23,4 @@ class ProductChangedEventHandler(
     override fun supports(eventType: EventType): Boolean {
         return EventType.PRODUCT_CHANGED == eventType
     }
-
 }

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/handler/ProductLikedEventHandler.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/handler/ProductLikedEventHandler.kt
@@ -1,0 +1,26 @@
+package com.loopers.domain.catalog.handler
+
+import com.loopers.domain.catalog.CatalogEventHandler
+import com.loopers.event.EventType
+import com.loopers.event.payload.productlike.ProductLikeChangedEvent
+import com.loopers.support.cache.CacheNames
+import com.loopers.support.cache.CacheRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class ProductLikedEventHandler(
+    private val cacheRepository: CacheRepository,
+) : CatalogEventHandler<ProductLikeChangedEvent> {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    override fun handle(eventPayload: ProductLikeChangedEvent) {
+        log.info("[ProductLikedEventHandler.handle] eventPayload: $eventPayload")
+        cacheRepository.evict(CacheNames.PRODUCT_LIKE_COUNT_V1 + eventPayload.productId)
+    }
+
+    override fun supports(eventType: EventType): Boolean {
+        return EventType.PRODUCT_LIKED == eventType
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/handler/ProductLikedEventHandler.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/handler/ProductLikedEventHandler.kt
@@ -2,7 +2,7 @@ package com.loopers.domain.catalog.handler
 
 import com.loopers.domain.catalog.CatalogEventHandler
 import com.loopers.event.EventType
-import com.loopers.event.payload.productlike.ProductLikeChangedEvent
+import com.loopers.event.payload.productlike.ProductLikedEvent
 import com.loopers.support.cache.CacheNames
 import com.loopers.support.cache.CacheRepository
 import org.slf4j.LoggerFactory
@@ -11,11 +11,11 @@ import org.springframework.stereotype.Component
 @Component
 class ProductLikedEventHandler(
     private val cacheRepository: CacheRepository,
-) : CatalogEventHandler<ProductLikeChangedEvent> {
+) : CatalogEventHandler<ProductLikedEvent> {
 
     private val log = LoggerFactory.getLogger(this::class.java)
 
-    override fun handle(eventPayload: ProductLikeChangedEvent) {
+    override fun handle(eventPayload: ProductLikedEvent) {
         log.info("[ProductLikedEventHandler.handle] eventPayload: $eventPayload")
         cacheRepository.evict(CacheNames.PRODUCT_LIKE_COUNT_V1 + eventPayload.productId)
     }

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/handler/ProductUnlikedEventHandler.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/handler/ProductUnlikedEventHandler.kt
@@ -2,7 +2,7 @@ package com.loopers.domain.catalog.handler
 
 import com.loopers.domain.catalog.CatalogEventHandler
 import com.loopers.event.EventType
-import com.loopers.event.payload.productlike.ProductLikeChangedEvent
+import com.loopers.event.payload.productlike.ProductUnlikedEvent
 import com.loopers.support.cache.CacheNames
 import com.loopers.support.cache.CacheRepository
 import org.slf4j.LoggerFactory
@@ -11,11 +11,11 @@ import org.springframework.stereotype.Component
 @Component
 class ProductUnlikedEventHandler(
     private val cacheRepository: CacheRepository,
-) : CatalogEventHandler<ProductLikeChangedEvent> {
+) : CatalogEventHandler<ProductUnlikedEvent> {
 
     private val log = LoggerFactory.getLogger(this::class.java)
 
-    override fun handle(eventPayload: ProductLikeChangedEvent) {
+    override fun handle(eventPayload: ProductUnlikedEvent) {
         log.info("[ProductUnlikedEventHandler.handle] eventPayload: $eventPayload")
         cacheRepository.evict(CacheNames.PRODUCT_LIKE_COUNT_V1 + eventPayload.productId)
     }

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/handler/ProductUnlikedEventHandler.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/handler/ProductUnlikedEventHandler.kt
@@ -1,0 +1,26 @@
+package com.loopers.domain.catalog.handler
+
+import com.loopers.domain.catalog.CatalogEventHandler
+import com.loopers.event.EventType
+import com.loopers.event.payload.productlike.ProductLikeChangedEvent
+import com.loopers.support.cache.CacheNames
+import com.loopers.support.cache.CacheRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class ProductUnlikedEventHandler(
+    private val cacheRepository: CacheRepository,
+) : CatalogEventHandler<ProductLikeChangedEvent> {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    override fun handle(eventPayload: ProductLikeChangedEvent) {
+        log.info("[ProductUnlikedEventHandler.handle] eventPayload: $eventPayload")
+        cacheRepository.evict(CacheNames.PRODUCT_LIKE_COUNT_V1 + eventPayload.productId)
+    }
+
+    override fun supports(eventType: EventType): Boolean {
+        return EventType.PRODUCT_UNLIKED == eventType
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/handler/StockAdjustedEventHandler.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/handler/StockAdjustedEventHandler.kt
@@ -1,0 +1,26 @@
+package com.loopers.domain.catalog.handler
+
+import com.loopers.domain.catalog.CatalogEventHandler
+import com.loopers.event.EventType
+import com.loopers.event.payload.stock.StockAdjustedEvent
+import com.loopers.support.cache.CacheNames
+import com.loopers.support.cache.CacheRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class StockAdjustedEventHandler(
+    private val cacheRepository: CacheRepository,
+) : CatalogEventHandler<StockAdjustedEvent> {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    override fun handle(eventPayload: StockAdjustedEvent) {
+        log.info("[StockAdjustedEventHandler.handle] eventPayload: $eventPayload")
+        cacheRepository.evict(CacheNames.PRODUCT_DETAIL_V1 + eventPayload.productId)
+    }
+
+    override fun supports(eventType: EventType): Boolean {
+        return EventType.PRODUCT_STOCK_ADJUSTED == eventType
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/handler/StockSoldOutEventHandler.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/catalog/handler/StockSoldOutEventHandler.kt
@@ -2,25 +2,25 @@ package com.loopers.domain.catalog.handler
 
 import com.loopers.domain.catalog.CatalogEventHandler
 import com.loopers.event.EventType
-import com.loopers.event.payload.stock.StockAdjustedEvent
+import com.loopers.event.payload.stock.StockSoldOutEvent
 import com.loopers.support.cache.CacheNames
 import com.loopers.support.cache.CacheRepository
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
 @Component
-class StockAdjustedEventHandler(
+class StockSoldOutEventHandler(
     private val cacheRepository: CacheRepository,
-) : CatalogEventHandler<StockAdjustedEvent> {
+) : CatalogEventHandler<StockSoldOutEvent> {
 
     private val log = LoggerFactory.getLogger(this::class.java)
 
-    override fun handle(eventPayload: StockAdjustedEvent) {
-        log.info("[StockAdjustedEventHandler.handle] eventPayload: $eventPayload")
+    override fun handle(eventPayload: StockSoldOutEvent) {
+        log.info("[StockSoldOutEventHandler.handle] eventPayload: $eventPayload")
         cacheRepository.evict(CacheNames.PRODUCT_DETAIL_V1 + eventPayload.productId)
     }
 
     override fun supports(eventType: EventType): Boolean {
-        return EventType.PRODUCT_STOCK_ADJUSTED == eventType
+        return EventType.PRODUCT_STOCK_SOLD_OUT == eventType
     }
 }

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/events/EventHandled.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/events/EventHandled.kt
@@ -1,0 +1,22 @@
+package com.loopers.domain.events
+
+import com.loopers.domain.BaseEntity
+import com.loopers.event.EventType
+import com.loopers.support.enums.EventHandleStatus
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "event_handled")
+class EventHandled(
+    val eventId: String,
+    val eventType: EventType,
+    val topic: String,
+    val partitionNo: Int,
+    val offsetNo: Long,
+    val consumerGroup: String,
+    @Enumerated(EnumType.STRING)
+    var status: EventHandleStatus,
+) : BaseEntity()

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/events/EventHandledCommand.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/events/EventHandledCommand.kt
@@ -1,0 +1,44 @@
+package com.loopers.domain.events
+
+import com.loopers.event.EventType
+import com.loopers.support.enums.EventHandleStatus
+
+class EventHandledCommand {
+    data class Succeed(
+        val eventId: String,
+        val eventType: EventType,
+        val topic: String,
+        val partitionNo: Int,
+        val offsetNo: Long,
+        val consumerGroup: String,
+    ) {
+        fun toEntity() = EventHandled(
+            eventId,
+            eventType,
+            topic,
+            partitionNo,
+            offsetNo,
+            consumerGroup,
+            EventHandleStatus.SUCCEED,
+        )
+    }
+
+    data class Failed(
+        val eventId: String,
+        val eventType: EventType,
+        val topic: String,
+        val partitionNo: Int,
+        val offsetNo: Long,
+        val consumerGroup: String,
+    ) {
+        fun toEntity() = EventHandled(
+            eventId,
+            eventType,
+            topic,
+            partitionNo,
+            offsetNo,
+            consumerGroup,
+            EventHandleStatus.FAILED,
+        )
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/events/EventHandledRepository.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/events/EventHandledRepository.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.events
+
+interface EventHandledRepository {
+    fun existsByEventIdAndConsumerGroup(eventId: String, consumerGroup: String): Boolean
+    fun findByEventIdAndConsumerGroup(eventId: String, consumerGroup: String): EventHandled?
+    fun save(eventHandled: EventHandled): EventHandled
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/events/EventHandledService.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/events/EventHandledService.kt
@@ -1,0 +1,37 @@
+package com.loopers.domain.events
+
+import jakarta.transaction.Transactional
+import org.slf4j.LoggerFactory
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.stereotype.Service
+
+@Service
+class EventHandledService(
+    private val eventHandledRepository: EventHandledRepository,
+) {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    fun isAlreadyHandled(eventId: String, consumerGroup: String): Boolean {
+        log.info("[EventHandledService.isAlreadyHandled] eventId: $eventId, consumerGroup: $consumerGroup")
+        return eventHandledRepository.existsByEventIdAndConsumerGroup(eventId, consumerGroup)
+    }
+
+    @Transactional
+    fun markSuccess(command: EventHandledCommand.Succeed) {
+        try {
+            eventHandledRepository.save(command.toEntity())
+        } catch (e: DataIntegrityViolationException) {
+            log.debug("[EventHandledService.markSuccess] already exists command: {}", command)
+        }
+    }
+
+    @Transactional
+    fun markFail(command: EventHandledCommand.Failed) {
+        try {
+            eventHandledRepository.save(command.toEntity())
+        } catch (e: DataIntegrityViolationException) {
+            log.debug("[EventHandledService.markFail] already exists command: {}", command)
+        }
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productmetrics/ProductMetrics.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productmetrics/ProductMetrics.kt
@@ -1,0 +1,63 @@
+package com.loopers.domain.productmetrics
+
+import com.loopers.domain.BaseEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.LocalDate
+
+@Entity
+@Table(
+    name = "product_metrics",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_product_metrics_product_date",
+            columnNames = ["product_id", "metric_date"],
+        ),
+    ],
+    indexes = [
+        Index(name = "idx_product_metrics_product_id", columnList = "product_id"),
+        Index(name = "idx_product_metrics_metric_date", columnList = "metric_date"),
+    ],
+)
+class ProductMetrics(
+    val productId: Long,
+    val metricDate: LocalDate,
+    var likeCount: Int = 0,
+    var viewCount: Int = 0,
+    var salesCount: Int = 0,
+) : BaseEntity() {
+
+    init {
+        require(productId > 0) { "상품 ID는 0보다 커야 합니다." }
+        require(likeCount >= 0) { "상품 좋아요 수는 0보다 작을 수 없습니다." }
+        require(viewCount >= 0) { "상품 조회 수는 0보다 작을 수 없습니다." }
+        require(salesCount >= 0) { "상품 판매 수는 0보다 작을 수 없습니다." }
+    }
+
+    fun increaseSalesCount(count: Int = 1) {
+        this.salesCount += count
+    }
+
+    fun increaseViewCount(count: Int = 1) {
+        this.viewCount += count
+    }
+
+    fun increaseLikeCount(count: Int = 1) {
+        this.likeCount += count
+    }
+
+    fun decreaseLikeCount(count: Int = 1) {
+        this.likeCount -= count
+    }
+
+    companion object {
+        fun init(productId: Long, metricDate: LocalDate): ProductMetrics {
+            return ProductMetrics(
+                productId,
+                metricDate,
+            )
+        }
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productmetrics/ProductMetricsEventHandler.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productmetrics/ProductMetricsEventHandler.kt
@@ -1,0 +1,10 @@
+package com.loopers.domain.productmetrics
+
+import com.loopers.event.EventType
+import com.loopers.event.payload.EventPayload
+
+interface ProductMetricsEventHandler<T : EventPayload> {
+    fun handle(eventPayload: T)
+
+    fun supports(eventType: EventType): Boolean
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productmetrics/ProductMetricsEventHandlerFactory.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productmetrics/ProductMetricsEventHandlerFactory.kt
@@ -1,0 +1,15 @@
+package com.loopers.domain.productmetrics
+
+import com.loopers.event.Event
+import com.loopers.event.payload.EventPayload
+import org.springframework.stereotype.Component
+
+@Component
+class ProductMetricsEventHandlerFactory(
+    private val handlers: List<ProductMetricsEventHandler<EventPayload>>,
+) {
+    fun handle(event: Event<EventPayload>) {
+        handlers.find { it.supports(event.eventType) }?.handle(event.payload)
+            ?: throw IllegalStateException("해당 이벤트를 처리할 핸들러가 없습니다.")
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productmetrics/ProductMetricsEventHandlerFactory.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productmetrics/ProductMetricsEventHandlerFactory.kt
@@ -6,10 +6,13 @@ import org.springframework.stereotype.Component
 
 @Component
 class ProductMetricsEventHandlerFactory(
-    private val handlers: List<ProductMetricsEventHandler<EventPayload>>,
+    private val handlers: List<ProductMetricsEventHandler<out EventPayload>>,
 ) {
-    fun handle(event: Event<EventPayload>) {
-        handlers.find { it.supports(event.eventType) }?.handle(event.payload)
-            ?: throw IllegalStateException("해당 이벤트를 처리할 핸들러가 없습니다.")
+    @Suppress("UNCHECKED_CAST")
+    fun <T : EventPayload> handle(event: Event<T>) {
+        val handler = (handlers.find { it.supports(event.eventType) }
+                as? ProductMetricsEventHandler<T>
+            ?: throw IllegalStateException("해당 이벤트를 처리할 핸들러가 없습니다."))
+        handler.handle(event.payload)
     }
 }

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productmetrics/ProductMetricsRepository.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productmetrics/ProductMetricsRepository.kt
@@ -1,0 +1,9 @@
+package com.loopers.domain.productmetrics
+
+import java.time.LocalDate
+
+interface ProductMetricsRepository {
+    fun findByProductIdAndMetricDate(productId: Long, metricDate: LocalDate): ProductMetrics?
+
+    fun save(productMetrics: ProductMetrics)
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productmetrics/ProductMetricsService.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productmetrics/ProductMetricsService.kt
@@ -1,0 +1,14 @@
+package com.loopers.domain.productmetrics
+
+import com.loopers.event.Event
+import com.loopers.event.payload.EventPayload
+import org.springframework.stereotype.Service
+
+@Service
+class ProductMetricsService(
+    private val eventHandlerFactory: ProductMetricsEventHandlerFactory,
+) {
+    fun handleEvent(event: Event<EventPayload>) {
+        eventHandlerFactory.handle(event)
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productmetrics/handler/ProductLikedEventHandlerProduct.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productmetrics/handler/ProductLikedEventHandlerProduct.kt
@@ -1,0 +1,30 @@
+package com.loopers.domain.productmetrics.handler
+
+import com.loopers.domain.productmetrics.ProductMetrics
+import com.loopers.domain.productmetrics.ProductMetricsEventHandler
+import com.loopers.domain.productmetrics.ProductMetricsRepository
+import com.loopers.event.EventType
+import com.loopers.event.payload.productlike.ProductLikedEvent
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+
+@Component
+class ProductLikedEventHandlerProduct(
+    private val productMetricsRepository: ProductMetricsRepository,
+) : ProductMetricsEventHandler<ProductLikedEvent> {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    override fun handle(eventPayload: ProductLikedEvent) {
+        log.info("[ProductLikedEventHandlerProduct.handle] eventPayload: $eventPayload")
+        val productMetrics = productMetricsRepository.findByProductIdAndMetricDate(eventPayload.productId, LocalDate.now())
+            ?: ProductMetrics.init(eventPayload.productId, LocalDate.now())
+        productMetrics.increaseLikeCount()
+        productMetricsRepository.save(productMetrics)
+    }
+
+    override fun supports(eventType: EventType): Boolean {
+        return EventType.PRODUCT_LIKED == eventType
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productmetrics/handler/ProductUnlikedEventHandlerProduct.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productmetrics/handler/ProductUnlikedEventHandlerProduct.kt
@@ -1,0 +1,30 @@
+package com.loopers.domain.productmetrics.handler
+
+import com.loopers.domain.productmetrics.ProductMetrics
+import com.loopers.domain.productmetrics.ProductMetricsEventHandler
+import com.loopers.domain.productmetrics.ProductMetricsRepository
+import com.loopers.event.EventType
+import com.loopers.event.payload.productlike.ProductUnlikedEvent
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+
+@Component
+class ProductUnlikedEventHandlerProduct(
+    private val productMetricsRepository: ProductMetricsRepository,
+) : ProductMetricsEventHandler<ProductUnlikedEvent> {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    override fun handle(eventPayload: ProductUnlikedEvent) {
+        log.info("[ProductUnlikedEventHandlerProduct.handle] eventPayload: $eventPayload")
+        val productMetrics = productMetricsRepository.findByProductIdAndMetricDate(eventPayload.productId, LocalDate.now())
+            ?: ProductMetrics.init(eventPayload.productId, LocalDate.now())
+        productMetrics.decreaseLikeCount()
+        productMetricsRepository.save(productMetrics)
+    }
+
+    override fun supports(eventType: EventType): Boolean {
+        return EventType.PRODUCT_UNLIKED == eventType
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productmetrics/handler/ProductViewedEventHandlerProduct.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productmetrics/handler/ProductViewedEventHandlerProduct.kt
@@ -1,0 +1,30 @@
+package com.loopers.domain.productmetrics.handler
+
+import com.loopers.domain.productmetrics.ProductMetrics
+import com.loopers.domain.productmetrics.ProductMetricsEventHandler
+import com.loopers.domain.productmetrics.ProductMetricsRepository
+import com.loopers.event.EventType
+import com.loopers.event.payload.product.ProductViewedEvent
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+
+@Component
+class ProductViewedEventHandlerProduct(
+    private val productMetricsRepository: ProductMetricsRepository,
+) : ProductMetricsEventHandler<ProductViewedEvent> {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    override fun handle(eventPayload: ProductViewedEvent) {
+        log.info("[ProductViewedEventHandlerProduct.handle] eventPayload: $eventPayload")
+        val productMetrics = productMetricsRepository.findByProductIdAndMetricDate(eventPayload.productId, LocalDate.now())
+            ?: ProductMetrics.init(eventPayload.productId, LocalDate.now())
+        productMetrics.increaseViewCount()
+        productMetricsRepository.save(productMetrics)
+    }
+
+    override fun supports(eventType: EventType): Boolean {
+        return EventType.PRODUCT_VIEWED == eventType
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productmetrics/handler/StockAdjustedEventHandlerProduct.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productmetrics/handler/StockAdjustedEventHandlerProduct.kt
@@ -1,0 +1,30 @@
+package com.loopers.domain.productmetrics.handler
+
+import com.loopers.domain.productmetrics.ProductMetrics
+import com.loopers.domain.productmetrics.ProductMetricsEventHandler
+import com.loopers.domain.productmetrics.ProductMetricsRepository
+import com.loopers.event.EventType
+import com.loopers.event.payload.stock.StockAdjustedEvent
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+
+@Component
+class StockAdjustedEventHandlerProduct(
+    private val productMetricsRepository: ProductMetricsRepository,
+) : ProductMetricsEventHandler<StockAdjustedEvent> {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    override fun handle(eventPayload: StockAdjustedEvent) {
+        log.info("[StockAdjustedEventHandlerProduct.handle] eventPayload: $eventPayload")
+        val productMetrics = productMetricsRepository.findByProductIdAndMetricDate(eventPayload.productId, LocalDate.now())
+            ?: ProductMetrics.init(eventPayload.productId, LocalDate.now())
+        productMetrics.increaseSalesCount(eventPayload.quantity)
+        productMetricsRepository.save(productMetrics)
+    }
+
+    override fun supports(eventType: EventType): Boolean {
+        return EventType.PRODUCT_STOCK_ADJUSTED == eventType
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/auditlog/AuditLogJpaRepository.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/auditlog/AuditLogJpaRepository.kt
@@ -1,0 +1,6 @@
+package com.loopers.infrastructure.auditlog
+
+import com.loopers.domain.auditlog.AuditLog
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AuditLogJpaRepository : JpaRepository<AuditLog, Long>

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/auditlog/AuditLogRepositoryImpl.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/auditlog/AuditLogRepositoryImpl.kt
@@ -1,0 +1,14 @@
+package com.loopers.infrastructure.auditlog
+
+import com.loopers.domain.auditlog.AuditLog
+import com.loopers.domain.auditlog.AuditLogRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class AuditLogRepositoryImpl(
+    private val auditLogJpaRepository: AuditLogJpaRepository,
+) : AuditLogRepository {
+    override fun save(auditLog: AuditLog) {
+        auditLogJpaRepository.save(auditLog)
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/eventhandled/EventHandledJpaRepository.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/eventhandled/EventHandledJpaRepository.kt
@@ -1,0 +1,9 @@
+package com.loopers.infrastructure.eventhandled
+
+import com.loopers.domain.events.EventHandled
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface EventHandledJpaRepository : JpaRepository<EventHandled, Long> {
+    fun existsByEventIdAndConsumerGroup(eventId: String, consumerGroup: String): Boolean
+    fun findByEventIdAndConsumerGroup(eventId: String, consumerGroup: String): EventHandled?
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/eventhandled/EventHandledRepositoryImpl.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/eventhandled/EventHandledRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package com.loopers.infrastructure.eventhandled
+
+import com.loopers.domain.events.EventHandled
+import com.loopers.domain.events.EventHandledRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class EventHandledRepositoryImpl(
+    private val eventHandledJpaRepository: EventHandledJpaRepository,
+) : EventHandledRepository {
+    override fun existsByEventIdAndConsumerGroup(eventId: String, consumerGroup: String): Boolean {
+        return eventHandledJpaRepository.existsByEventIdAndConsumerGroup(eventId, consumerGroup)
+    }
+
+    override fun findByEventIdAndConsumerGroup(eventId: String, consumerGroup: String): EventHandled? {
+        return eventHandledJpaRepository.findByEventIdAndConsumerGroup(eventId, consumerGroup)
+    }
+
+    override fun save(eventHandled: EventHandled): EventHandled {
+        return eventHandledJpaRepository.save(eventHandled)
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/productmetrics/ProductMetricsJpaRepository.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/productmetrics/ProductMetricsJpaRepository.kt
@@ -1,0 +1,9 @@
+package com.loopers.infrastructure.productmetrics
+
+import com.loopers.domain.productmetrics.ProductMetrics
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDate
+
+interface ProductMetricsJpaRepository : JpaRepository<ProductMetrics, Long> {
+    fun findByProductIdAndMetricDate(productId: Long, metricDate: LocalDate): ProductMetrics?
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/productmetrics/ProductMetricsRepositoryImpl.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/productmetrics/ProductMetricsRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.productmetrics
+
+import com.loopers.domain.productmetrics.ProductMetrics
+import com.loopers.domain.productmetrics.ProductMetricsRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+
+@Repository
+class ProductMetricsRepositoryImpl(
+    private val productMetricsJpaRepository: ProductMetricsJpaRepository,
+) : ProductMetricsRepository {
+    override fun findByProductIdAndMetricDate(productId: Long, metricDate: LocalDate): ProductMetrics? {
+        return productMetricsJpaRepository.findByProductIdAndMetricDate(productId, metricDate)
+    }
+
+    override fun save(productMetrics: ProductMetrics) {
+        productMetricsJpaRepository.save(productMetrics)
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/auditlog/consumer/AuditLogV1EventConsumer.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/auditlog/consumer/AuditLogV1EventConsumer.kt
@@ -1,0 +1,54 @@
+package com.loopers.interfaces.auditlog.consumer
+
+import com.loopers.domain.auditlog.AuditLogCommand
+import com.loopers.domain.auditlog.AuditLogService
+import com.loopers.event.Event
+import com.loopers.event.EventType.Group
+import com.loopers.event.EventType.Topic
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.kafka.support.KafkaHeaders
+import org.springframework.messaging.handler.annotation.Header
+import org.springframework.stereotype.Component
+
+@Component
+class AuditLogV1EventConsumer(
+    private val auditLogService: AuditLogService,
+) {
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    @KafkaListener(
+        topics = [
+            Topic.PRODUCT_V1_STOCK_ADJUSTED,
+            Topic.PRODUCT_V1_CHANGED,
+            Topic.PRODUCT_V1_LIKE_CHANGED,
+            Topic.PRODUCT_V1_VIEWED,
+        ],
+        groupId = Group.AUDIT_LOG_EVENTS,
+    )
+    fun listen(
+        message: String,
+        ack: Acknowledgment,
+        @Header(KafkaHeaders.RECEIVED_TOPIC) topic: String,
+        @Header(KafkaHeaders.RECEIVED_PARTITION) partition: Int,
+        @Header(KafkaHeaders.OFFSET) offset: Long,
+    ) {
+        log.info("[AuditLogV1EventConsumer.listen] message: $message")
+        log.info("Received message from topic: $topic, partition: $partition, offset: $offset")
+        val event = Event.fromJson(message) ?: throw IllegalArgumentException("Invalid event message: $message")
+
+        auditLogService.saveAuditLog(
+            AuditLogCommand.Create(
+                event.eventId,
+                event.eventType,
+                topic,
+                partition,
+                offset,
+                message,
+            ),
+        )
+
+        ack.acknowledge()
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/catalog/consumer/CatalogV1EventConsumer.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/catalog/consumer/CatalogV1EventConsumer.kt
@@ -12,6 +12,7 @@ import org.springframework.kafka.support.Acknowledgment
 import org.springframework.kafka.support.KafkaHeaders
 import org.springframework.messaging.handler.annotation.Header
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 @Component
 class CatalogV1EventConsumer(
@@ -25,6 +26,7 @@ class CatalogV1EventConsumer(
         topics = [Topic.PRODUCT_V1_STOCK_SOLD_OUT, Topic.PRODUCT_V1_CHANGED, Topic.PRODUCT_V1_LIKE_CHANGED],
         groupId = Group.CATALOG_EVENTS,
     )
+    @Transactional
     fun listen(
         message: String,
         ack: Acknowledgment,

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/catalog/consumer/CatalogV1EventConsumer.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/catalog/consumer/CatalogV1EventConsumer.kt
@@ -1,31 +1,57 @@
 package com.loopers.interfaces.catalog.consumer
 
 import com.loopers.domain.catalog.CatalogService
+import com.loopers.domain.events.EventHandledCommand
+import com.loopers.domain.events.EventHandledService
 import com.loopers.event.Event
 import com.loopers.event.EventType.Group
 import com.loopers.event.EventType.Topic
 import org.slf4j.LoggerFactory
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.kafka.support.Acknowledgment
+import org.springframework.kafka.support.KafkaHeaders
+import org.springframework.messaging.handler.annotation.Header
 import org.springframework.stereotype.Component
 
 @Component
 class CatalogV1EventConsumer(
     private val catalogService: CatalogService,
+    private val eventHandledService: EventHandledService,
 ) {
 
     private val log = LoggerFactory.getLogger(this::class.java)
 
     @KafkaListener(
-        topics = [Topic.PRODUCT_STOCK_ADJUSTED, Topic.PRODUCT_CHANGED, Topic.PRODUCT_LIKE_CHANGED],
+        topics = [Topic.PRODUCT_V1_STOCK_ADJUSTED, Topic.PRODUCT_V1_CHANGED, Topic.PRODUCT_V1_LIKE_CHANGED],
         groupId = Group.CATALOG_EVENTS,
     )
-    fun listen(message: String, ack: Acknowledgment) {
+    fun listen(
+        message: String,
+        ack: Acknowledgment,
+        @Header(KafkaHeaders.RECEIVED_TOPIC) topic: String,
+        @Header(KafkaHeaders.RECEIVED_PARTITION) partition: Int,
+        @Header(KafkaHeaders.OFFSET) offset: Long,
+    ) {
         log.info("[CatalogV1EventConsumer.listen] message: $message")
-        val event = Event.fromJson(message)
-        event?.let {
-            catalogService.handleEvent(it)
+        val event = Event.fromJson(message) ?: throw IllegalArgumentException("Invalid event message: $message")
+
+        if (eventHandledService.isAlreadyHandled(event.eventId, Group.CATALOG_EVENTS)) {
+            log.info("[CatalogV1EventConsumer.listen] already handled eventId: ${event.eventId}, group: ${Group.CATALOG_EVENTS}")
+            ack.acknowledge()
+            return
         }
+
+        catalogService.handleEvent(event)
+        eventHandledService.markSuccess(
+            EventHandledCommand.Succeed(
+                event.eventId,
+                event.eventType,
+                topic,
+                partition,
+                offset,
+                Group.CATALOG_EVENTS,
+            ),
+        )
         ack.acknowledge()
     }
 }

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/catalog/consumer/CatalogV1EventConsumer.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/catalog/consumer/CatalogV1EventConsumer.kt
@@ -22,7 +22,7 @@ class CatalogV1EventConsumer(
     private val log = LoggerFactory.getLogger(this::class.java)
 
     @KafkaListener(
-        topics = [Topic.PRODUCT_V1_STOCK_ADJUSTED, Topic.PRODUCT_V1_CHANGED, Topic.PRODUCT_V1_LIKE_CHANGED],
+        topics = [Topic.PRODUCT_V1_STOCK_SOLD_OUT, Topic.PRODUCT_V1_CHANGED, Topic.PRODUCT_V1_LIKE_CHANGED],
         groupId = Group.CATALOG_EVENTS,
     )
     fun listen(

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/catalog/consumer/CatalogV1EventConsumer.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/catalog/consumer/CatalogV1EventConsumer.kt
@@ -1,0 +1,31 @@
+package com.loopers.interfaces.catalog.consumer
+
+import com.loopers.domain.catalog.CatalogService
+import com.loopers.event.Event
+import com.loopers.event.EventType.Group
+import com.loopers.event.EventType.Topic
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+
+@Component
+class CatalogV1EventConsumer(
+    private val catalogService: CatalogService,
+) {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    @KafkaListener(
+        topics = [Topic.PRODUCT_STOCK_ADJUSTED, Topic.PRODUCT_CHANGED, Topic.PRODUCT_LIKE_CHANGED],
+        groupId = Group.CATALOG_EVENTS,
+    )
+    fun listen(message: String, ack: Acknowledgment) {
+        log.info("[CatalogV1EventConsumer.listen] message: $message")
+        val event = Event.fromJson(message)
+        event?.let {
+            catalogService.handleEvent(it)
+        }
+        ack.acknowledge()
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/dlt/consumer/DLTV1Consumer.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/dlt/consumer/DLTV1Consumer.kt
@@ -1,0 +1,28 @@
+package com.loopers.interfaces.dlt.consumer
+
+import com.loopers.event.EventType.Group
+import com.loopers.event.EventType.Topic
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+
+@Component
+class DLTV1Consumer {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    @KafkaListener(
+        topics = [
+            Topic.PRODUCT_V1_CHANGED_DLT,
+            Topic.PRODUCT_V1_STOCK_ADJUSTED_DLT,
+            Topic.PRODUCT_V1_LIKE_CHANGED_DLT,
+            Topic.PRODUCT_V1_VIEWED_DLT,
+        ],
+        groupId = Group.DLT_EVENTS,
+    )
+    fun listen(message: String, ack: Acknowledgment) {
+        log.info("[DLTV1Consumer.listen] message: $message")
+        ack.acknowledge()
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/productmetrics/consumer/ProductMetricsV1EventConsumer.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/productmetrics/consumer/ProductMetricsV1EventConsumer.kt
@@ -12,6 +12,7 @@ import org.springframework.kafka.support.Acknowledgment
 import org.springframework.kafka.support.KafkaHeaders
 import org.springframework.messaging.handler.annotation.Header
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 @Component
 class ProductMetricsV1EventConsumer(
@@ -24,6 +25,7 @@ class ProductMetricsV1EventConsumer(
         topics = [Topic.PRODUCT_V1_STOCK_ADJUSTED, Topic.PRODUCT_V1_LIKE_CHANGED, Topic.PRODUCT_V1_VIEWED],
         groupId = Group.METRICS_EVENTS,
     )
+    @Transactional
     fun listen(
         message: String,
         ack: Acknowledgment,
@@ -52,5 +54,6 @@ class ProductMetricsV1EventConsumer(
             ),
         )
         ack.acknowledge()
+        throw RuntimeException("test exception")
     }
 }

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/productmetrics/consumer/ProductMetricsV1EventConsumer.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/productmetrics/consumer/ProductMetricsV1EventConsumer.kt
@@ -54,6 +54,5 @@ class ProductMetricsV1EventConsumer(
             ),
         )
         ack.acknowledge()
-        throw RuntimeException("test exception")
     }
 }

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/productmetrics/consumer/ProductMetricsV1EventConsumer.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/productmetrics/consumer/ProductMetricsV1EventConsumer.kt
@@ -1,0 +1,56 @@
+package com.loopers.interfaces.productmetrics.consumer
+
+import com.loopers.domain.events.EventHandledCommand
+import com.loopers.domain.events.EventHandledService
+import com.loopers.domain.productmetrics.ProductMetricsService
+import com.loopers.event.Event
+import com.loopers.event.EventType.Group
+import com.loopers.event.EventType.Topic
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.kafka.support.KafkaHeaders
+import org.springframework.messaging.handler.annotation.Header
+import org.springframework.stereotype.Component
+
+@Component
+class ProductMetricsV1EventConsumer(
+    private val productMetricsService: ProductMetricsService,
+    private val eventHandledService: EventHandledService,
+) {
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    @KafkaListener(
+        topics = [Topic.PRODUCT_V1_STOCK_ADJUSTED, Topic.PRODUCT_V1_LIKE_CHANGED, Topic.PRODUCT_V1_VIEWED],
+        groupId = Group.METRICS_EVENTS,
+    )
+    fun listen(
+        message: String,
+        ack: Acknowledgment,
+        @Header(KafkaHeaders.RECEIVED_TOPIC) topic: String,
+        @Header(KafkaHeaders.RECEIVED_PARTITION) partition: Int,
+        @Header(KafkaHeaders.OFFSET) offset: Long,
+    ) {
+        log.info("[MetricsV1EventConsumer.listen] message: $message")
+        val event = Event.fromJson(message) ?: throw IllegalArgumentException("Invalid event message: $message")
+
+        if (eventHandledService.isAlreadyHandled(event.eventId, Group.METRICS_EVENTS)) {
+            log.info("[MetricsV1EventConsumer.listen] already handled eventId: ${event.eventId}, group: ${Group.METRICS_EVENTS}")
+            ack.acknowledge()
+            return
+        }
+
+        productMetricsService.handleEvent(event)
+        eventHandledService.markSuccess(
+            EventHandledCommand.Succeed(
+                event.eventId,
+                event.eventType,
+                topic,
+                partition,
+                offset,
+                Group.METRICS_EVENTS,
+            ),
+        )
+        ack.acknowledge()
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/support/cache/CacheKey.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/support/cache/CacheKey.kt
@@ -3,7 +3,6 @@ package com.loopers.support.cache
 import java.time.Duration
 
 object CacheNames {
-    const val PRODUCT_LIST_V1 = "product:list:v1:"
     const val PRODUCT_DETAIL_V1 = "product:detail:v1:"
     const val PRODUCT_LIKE_COUNT_V1 = "product:like-count:v1:"
     const val BRAND_DETAIL_V1 = "brand:detail:v1:"

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/support/cache/CacheRedisRepository.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/support/cache/CacheRedisRepository.kt
@@ -1,6 +1,7 @@
 package com.loopers.support.cache
 
-import org.slf4j.LoggerFactory
+import DataSerializer
+import org.slf4j.LoggerFactory.getLogger
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Component
 import java.time.Duration
@@ -11,7 +12,7 @@ private class CacheRedisRepository(
     private val redisTemplate: RedisTemplate<String, String>,
 ) : CacheRepository {
 
-    private val log = LoggerFactory.getLogger(this::class.java)
+    private val log = getLogger(this::class.java)
 
     override fun <T> get(cacheKey: CacheKey, clazz: Class<T>): T? {
         val value = redisTemplate.opsForValue().get(cacheKey.fullKey()) ?: return null

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/support/cache/CacheRepository.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/support/cache/CacheRepository.kt
@@ -1,0 +1,9 @@
+package com.loopers.support.cache
+
+interface CacheRepository {
+    fun <T> get(cacheKey: CacheKey, clazz: Class<T>): T?
+
+    fun <T> set(cacheKey: CacheKey, value: T)
+
+    fun evict(key: String)
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/support/enums/EventHandleStatus.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/support/enums/EventHandleStatus.kt
@@ -1,0 +1,6 @@
+package com.loopers.support.enums
+
+enum class EventHandleStatus {
+    SUCCEED,
+    FAILED,
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/support/error/CoreException.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/support/error/CoreException.kt
@@ -1,0 +1,6 @@
+package com.loopers.support.error
+
+class CoreException(
+    val errorType: ErrorType,
+    val customMessage: String? = null,
+) : RuntimeException(customMessage ?: errorType.message)

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/support/error/ErrorType.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/support/error/ErrorType.kt
@@ -1,0 +1,11 @@
+package com.loopers.support.error
+
+import org.springframework.http.HttpStatus
+
+enum class ErrorType(val status: HttpStatus, val code: String, val message: String) {
+    /** 범용 에러 */
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.reasonPhrase, "일시적인 오류가 발생했습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.reasonPhrase, "잘못된 요청입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.reasonPhrase, "존재하지 않는 요청입니다."),
+    CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.reasonPhrase, "이미 존재하는 리소스입니다."),
+}

--- a/apps/commerce-streamer/src/main/resources/application.yml
+++ b/apps/commerce-streamer/src/main/resources/application.yml
@@ -1,0 +1,73 @@
+server:
+  shutdown: graceful
+  tomcat:
+    threads:
+      max: 200 # 최대 워커 스레드 수 (default : 200)
+      min-spare: 10 # 최소 유지 스레드 수 (default : 10)
+    connection-timeout: 1m # 연결 타임아웃 (ms) (default : 60000ms = 1m)
+    max-connections: 8192 # 최대 동시 연결 수 (default : 8192)
+    accept-count: 100 # 대기 큐 크기 (default : 100)
+    keep-alive-timeout: 60s # 60s
+  max-http-request-header-size: 8KB
+
+spring:
+  main:
+    web-application-type: servlet
+  application:
+    name: commerce-api
+  profiles:
+    active: local
+  config:
+    import:
+      - jpa.yml
+      - redis.yml
+      - kafka.yml
+      - logging.yml
+      - monitoring.yml
+
+springdoc:
+  use-fqn: true
+  swagger-ui:
+    path: /swagger-ui.html
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local, test
+
+server:
+  port: 8084
+
+management:
+  server:
+    port: 8085
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+server:
+  port: 8084
+
+management:
+  server:
+    port: 8085
+
+---
+spring:
+  config:
+    activate:
+      on-profile: qa
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prd
+
+springdoc:
+  api-docs:
+    enabled: false

--- a/http/commerce-api/brand/brand.http
+++ b/http/commerce-api/brand/brand.http
@@ -1,0 +1,9 @@
+### 브랜드 요청
+POST http://127.0.0.1:8080/api/v1/brands
+Content-Type: application/json
+Accept: application/json
+X-USER-ID: soonho
+
+{
+  "name": "브랜드명"
+}

--- a/http/commerce-api/product/product.http
+++ b/http/commerce-api/product/product.http
@@ -1,0 +1,16 @@
+### 상품 생성 요청
+POST http://127.0.0.1:8080/api/v1/products
+Content-Type: application/json
+Accept: application/json
+X-USER-ID: soonho
+
+{
+  "brandId": 1,
+  "name": "딸기아이스크림2",
+  "price": 4500,
+  "description": "신선한 딸기로 만든 아이스크림22",
+  "status": "ACTIVE"
+}
+
+### 상품 조회 요청
+GET http://127.0.0.1:8080/api/v1/products/2

--- a/http/commerce-api/productlike/productlike.http
+++ b/http/commerce-api/productlike/productlike.http
@@ -1,0 +1,15 @@
+### 상품 좋아요 등록
+POST http://127.0.0.1:8080/api/v1/like/products/1
+Content-Type: application/json
+Accept: application/json
+X-USER-ID: soonho
+
+###
+
+### 상품 좋아요 취소
+DELETE http://127.0.0.1:8080/api/v1/like/products/1
+Content-Type: application/json
+Accept: application/json
+X-USER-ID: soonho
+
+

--- a/http/commerce-api/user/user.http
+++ b/http/commerce-api/user/user.http
@@ -1,0 +1,12 @@
+### 회원가입 요청
+POST http://127.0.0.1:8080/api/v1/users
+Content-Type: application/json
+Accept: application/json
+
+{
+  "username": "soonho",
+  "name": "soonho",
+  "email": "soonho@example.com",
+  "birthday": "1995-05-15",
+  "gender": "M"
+}

--- a/modules/data-serializer/src/main/kotlin/com/loopers/dataserializer/DataSerializer.kt
+++ b/modules/data-serializer/src/main/kotlin/com/loopers/dataserializer/DataSerializer.kt
@@ -25,7 +25,7 @@ object DataSerializer {
         }
     }
 
-    fun <T> deserialize(data: Any?, clazz: Class<T>): T? {
+    fun <T> deserialize(data: Any?, clazz: Class<T>): T {
         return objectMapper.convertValue(data, clazz)
     }
 

--- a/modules/event/build.gradle.kts
+++ b/modules/event/build.gradle.kts
@@ -1,4 +1,6 @@
 dependencies {
     // web
     implementation("org.springframework.boot:spring-boot-starter-web")
+
+    implementation(project(":modules:data-serializer"))
 }

--- a/modules/event/src/main/kotlin/com/loopers/event/Event.kt
+++ b/modules/event/src/main/kotlin/com/loopers/event/Event.kt
@@ -1,0 +1,46 @@
+package com.loopers.event
+
+import DataSerializer
+import com.loopers.event.payload.EventPayload
+
+
+class Event<T : EventPayload>(
+    val eventId: String,
+    val eventType: EventType,
+    val payload: T,
+) {
+
+    fun toJson(): String? {
+        return DataSerializer.serialize(this)
+    }
+
+    companion object {
+        fun of(eventId: String, eventType: EventType, payload: EventPayload): Event<EventPayload> {
+            return Event(eventId, eventType, payload)
+        }
+
+        fun fromJson(json: String?): Event<EventPayload>? {
+            val eventRaw = DataSerializer.deserialize(json, EventRaw::class.java) ?: return null
+            val event: Event<EventPayload> = Event(
+                eventRaw.eventId,
+                EventType.valueOf(eventRaw.eventType),
+                DataSerializer.deserialize(eventRaw.payload, EventType.valueOf(eventRaw.eventType).payloadClass),
+            )
+            return event
+        }
+    }
+
+    data class EventRaw(
+        val eventId: String,
+        val eventType: String,
+        val payload: Any,
+    ) {
+        fun toEvent(type: Class<EventPayload>): Event<EventPayload> {
+            return of(
+                eventId,
+                EventType.valueOf(eventType),
+                DataSerializer.deserialize(payload, type),
+            )
+        }
+    }
+}

--- a/modules/event/src/main/kotlin/com/loopers/event/Event.kt
+++ b/modules/event/src/main/kotlin/com/loopers/event/Event.kt
@@ -3,7 +3,6 @@ package com.loopers.event
 import DataSerializer
 import com.loopers.event.payload.EventPayload
 
-
 class Event<T : EventPayload>(
     val eventId: String,
     val eventType: EventType,

--- a/modules/event/src/main/kotlin/com/loopers/event/EventType.kt
+++ b/modules/event/src/main/kotlin/com/loopers/event/EventType.kt
@@ -1,0 +1,32 @@
+package com.loopers.event
+
+import com.loopers.event.payload.EventPayload
+import com.loopers.event.payload.product.ProductChangedEvent
+import com.loopers.event.payload.productlike.ProductLikeChangedEvent
+import com.loopers.event.payload.stock.StockAdjustedEvent
+
+enum class EventType(
+    val payloadClass: Class<out EventPayload>,
+    val topic: String,
+) {
+    PRODUCT_CHANGED(ProductChangedEvent::class.java, Topic.PRODUCT_CHANGED),
+    PRODUCT_STOCK_ADJUSTED(StockAdjustedEvent::class.java, Topic.PRODUCT_STOCK_ADJUSTED),
+    PRODUCT_LIKED(ProductLikeChangedEvent::class.java, Topic.PRODUCT_LIKE_CHANGED),
+    PRODUCT_UNLIKED(ProductLikeChangedEvent::class.java, Topic.PRODUCT_LIKE_CHANGED),
+    ;
+
+
+    class Topic {
+        companion object {
+            const val PRODUCT_CHANGED = "product-changed"
+            const val PRODUCT_STOCK_ADJUSTED = "product-stock-adjusted"
+            const val PRODUCT_LIKE_CHANGED = "product-like-changed"
+        }
+    }
+
+    class Group {
+        companion object {
+            const val CATALOG_EVENTS = "catalog-events-listener-group"
+        }
+    }
+}

--- a/modules/event/src/main/kotlin/com/loopers/event/EventType.kt
+++ b/modules/event/src/main/kotlin/com/loopers/event/EventType.kt
@@ -2,31 +2,45 @@ package com.loopers.event
 
 import com.loopers.event.payload.EventPayload
 import com.loopers.event.payload.product.ProductChangedEvent
-import com.loopers.event.payload.productlike.ProductLikeChangedEvent
+import com.loopers.event.payload.product.ProductViewedEvent
+import com.loopers.event.payload.productlike.ProductLikedEvent
+import com.loopers.event.payload.productlike.ProductUnlikedEvent
 import com.loopers.event.payload.stock.StockAdjustedEvent
 
 enum class EventType(
     val payloadClass: Class<out EventPayload>,
     val topic: String,
 ) {
-    PRODUCT_CHANGED(ProductChangedEvent::class.java, Topic.PRODUCT_CHANGED),
-    PRODUCT_STOCK_ADJUSTED(StockAdjustedEvent::class.java, Topic.PRODUCT_STOCK_ADJUSTED),
-    PRODUCT_LIKED(ProductLikeChangedEvent::class.java, Topic.PRODUCT_LIKE_CHANGED),
-    PRODUCT_UNLIKED(ProductLikeChangedEvent::class.java, Topic.PRODUCT_LIKE_CHANGED),
+    PRODUCT_CHANGED(ProductChangedEvent::class.java, Topic.PRODUCT_V1_CHANGED),
+    PRODUCT_STOCK_ADJUSTED(StockAdjustedEvent::class.java, Topic.PRODUCT_V1_STOCK_ADJUSTED),
+    PRODUCT_LIKED(ProductLikedEvent::class.java, Topic.PRODUCT_V1_LIKE_CHANGED),
+    PRODUCT_UNLIKED(ProductUnlikedEvent::class.java, Topic.PRODUCT_V1_LIKE_CHANGED),
+    PRODUCT_VIEWED(ProductViewedEvent::class.java, Topic.PRODUCT_V1_VIEWED),
     ;
-
 
     class Topic {
         companion object {
-            const val PRODUCT_CHANGED = "product-changed"
-            const val PRODUCT_STOCK_ADJUSTED = "product-stock-adjusted"
-            const val PRODUCT_LIKE_CHANGED = "product-like-changed"
+            const val PRODUCT_V1_CHANGED = "product.v1.changed"
+            const val PRODUCT_V1_STOCK_ADJUSTED = "product.v1.stock-adjusted"
+            const val PRODUCT_V1_LIKE_CHANGED = "product.v1.like-changed"
+            const val PRODUCT_V1_VIEWED = "product.v1.viewed"
+
+            // DLT
+            const val PRODUCT_V1_CHANGED_DLT = "product.v1.changed.dlt"
+            const val PRODUCT_V1_STOCK_ADJUSTED_DLT = "product.v1.stock-adjusted.dlt"
+            const val PRODUCT_V1_LIKE_CHANGED_DLT = "product.v1.like-changed.dlt"
+            const val PRODUCT_V1_VIEWED_DLT = "product.v1.viewed.dlt"
         }
     }
 
     class Group {
         companion object {
-            const val CATALOG_EVENTS = "catalog-events-listener-group"
+            const val CATALOG_EVENTS = "catalog-events-consumer"
+            const val METRICS_EVENTS = "metrics-events-consumer"
+            const val AUDIT_LOG_EVENTS = "audit-log-events-consumer"
+
+            // DLT
+            const val DLT_EVENTS = "dlt-events-consumer"
         }
     }
 }

--- a/modules/event/src/main/kotlin/com/loopers/event/EventType.kt
+++ b/modules/event/src/main/kotlin/com/loopers/event/EventType.kt
@@ -6,6 +6,7 @@ import com.loopers.event.payload.product.ProductViewedEvent
 import com.loopers.event.payload.productlike.ProductLikedEvent
 import com.loopers.event.payload.productlike.ProductUnlikedEvent
 import com.loopers.event.payload.stock.StockAdjustedEvent
+import com.loopers.event.payload.stock.StockSoldOutEvent
 
 enum class EventType(
     val payloadClass: Class<out EventPayload>,
@@ -13,6 +14,7 @@ enum class EventType(
 ) {
     PRODUCT_CHANGED(ProductChangedEvent::class.java, Topic.PRODUCT_V1_CHANGED),
     PRODUCT_STOCK_ADJUSTED(StockAdjustedEvent::class.java, Topic.PRODUCT_V1_STOCK_ADJUSTED),
+    PRODUCT_STOCK_SOLD_OUT(StockSoldOutEvent::class.java, Topic.PRODUCT_V1_STOCK_SOLD_OUT),
     PRODUCT_LIKED(ProductLikedEvent::class.java, Topic.PRODUCT_V1_LIKE_CHANGED),
     PRODUCT_UNLIKED(ProductUnlikedEvent::class.java, Topic.PRODUCT_V1_LIKE_CHANGED),
     PRODUCT_VIEWED(ProductViewedEvent::class.java, Topic.PRODUCT_V1_VIEWED),
@@ -22,12 +24,14 @@ enum class EventType(
         companion object {
             const val PRODUCT_V1_CHANGED = "product.v1.changed"
             const val PRODUCT_V1_STOCK_ADJUSTED = "product.v1.stock-adjusted"
+            const val PRODUCT_V1_STOCK_SOLD_OUT = "product.v1.stock-sold-out"
             const val PRODUCT_V1_LIKE_CHANGED = "product.v1.like-changed"
             const val PRODUCT_V1_VIEWED = "product.v1.viewed"
 
             // DLT
             const val PRODUCT_V1_CHANGED_DLT = "product.v1.changed.dlt"
             const val PRODUCT_V1_STOCK_ADJUSTED_DLT = "product.v1.stock-adjusted.dlt"
+            const val PRODUCT_V1_STOCK_SOLD_OUT_DLT = "product.v1.stock-sold-out.dlt"
             const val PRODUCT_V1_LIKE_CHANGED_DLT = "product.v1.like-changed.dlt"
             const val PRODUCT_V1_VIEWED_DLT = "product.v1.viewed.dlt"
         }

--- a/modules/event/src/main/kotlin/com/loopers/event/handler/EventHandler.kt
+++ b/modules/event/src/main/kotlin/com/loopers/event/handler/EventHandler.kt
@@ -1,5 +1,0 @@
-package com.loopers.event.handler
-
-interface EventHandler<T> {
-    fun handle(event: T)
-}

--- a/modules/event/src/main/kotlin/com/loopers/event/payload/product/ProductChangedEvent.kt
+++ b/modules/event/src/main/kotlin/com/loopers/event/payload/product/ProductChangedEvent.kt
@@ -1,0 +1,7 @@
+package com.loopers.event.payload.product
+
+import com.loopers.event.payload.EventPayload
+
+data class ProductChangedEvent(
+    val productId: Long,
+) : EventPayload

--- a/modules/event/src/main/kotlin/com/loopers/event/payload/productlike/ProductLikeChangedEvent.kt
+++ b/modules/event/src/main/kotlin/com/loopers/event/payload/productlike/ProductLikeChangedEvent.kt
@@ -1,0 +1,7 @@
+package com.loopers.event.payload.productlike
+
+import com.loopers.event.payload.EventPayload
+
+data class ProductLikeChangedEvent(
+    val productId: Long,
+) : EventPayload

--- a/modules/event/src/main/kotlin/com/loopers/event/payload/productlike/ProductLikedEvent.kt
+++ b/modules/event/src/main/kotlin/com/loopers/event/payload/productlike/ProductLikedEvent.kt
@@ -2,6 +2,6 @@ package com.loopers.event.payload.productlike
 
 import com.loopers.event.payload.EventPayload
 
-data class ProductLikeEvent(
+data class ProductLikedEvent(
     val productId: Long,
 ) : EventPayload

--- a/modules/event/src/main/kotlin/com/loopers/event/payload/productlike/ProductUnlikeEvent.kt
+++ b/modules/event/src/main/kotlin/com/loopers/event/payload/productlike/ProductUnlikeEvent.kt
@@ -1,7 +1,0 @@
-package com.loopers.event.payload.productlike
-
-import com.loopers.event.payload.EventPayload
-
-data class ProductUnlikeEvent(
-    val productId: Long,
-) : EventPayload

--- a/modules/event/src/main/kotlin/com/loopers/event/payload/productlike/ProductUnlikedEvent.kt
+++ b/modules/event/src/main/kotlin/com/loopers/event/payload/productlike/ProductUnlikedEvent.kt
@@ -2,6 +2,6 @@ package com.loopers.event.payload.productlike
 
 import com.loopers.event.payload.EventPayload
 
-data class ProductLikeChangedEvent(
+data class ProductUnlikedEvent(
     val productId: Long,
 ) : EventPayload

--- a/modules/event/src/main/kotlin/com/loopers/event/payload/stock/StockAdjustedEvent.kt
+++ b/modules/event/src/main/kotlin/com/loopers/event/payload/stock/StockAdjustedEvent.kt
@@ -4,4 +4,5 @@ import com.loopers.event.payload.EventPayload
 
 data class StockAdjustedEvent(
     val productId: Long,
+    val quantity: Int,
 ) : EventPayload

--- a/modules/event/src/main/kotlin/com/loopers/event/payload/stock/StockAdjustedEvent.kt
+++ b/modules/event/src/main/kotlin/com/loopers/event/payload/stock/StockAdjustedEvent.kt
@@ -1,0 +1,7 @@
+package com.loopers.event.payload.stock
+
+import com.loopers.event.payload.EventPayload
+
+data class StockAdjustedEvent(
+    val productId: Long,
+) : EventPayload

--- a/modules/event/src/main/kotlin/com/loopers/event/payload/stock/StockSoldOutEvent.kt
+++ b/modules/event/src/main/kotlin/com/loopers/event/payload/stock/StockSoldOutEvent.kt
@@ -1,0 +1,7 @@
+package com.loopers.event.payload.stock
+
+import com.loopers.event.payload.EventPayload
+
+class StockSoldOutEvent(
+    val productId: Long,
+) : EventPayload

--- a/modules/kafka/src/main/resources/kafka.yml
+++ b/modules/kafka/src/main/resources/kafka.yml
@@ -15,6 +15,9 @@ spring:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       retries: 3
+      acks: all
+      enable-idempotence: true
+      max-in-flight-requests-per-connection: 1
     consumer:
       group-id: loopers-default-consumer
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "soono-gamsung-commerce"
 
 include(
     ":apps:commerce-api",
+    ":apps:commerce-streamer",
     ":apps:pg-simulator",
     ":modules:jpa",
     ":modules:redis",


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->
# 이벤트 설계
- 이벤트를 다음과 같은 흐름으로 설계했습니다.

## 상품 조회 이벤트 흐름
<img width="500" height="649" alt="상품조회" src="https://github.com/user-attachments/assets/cbced374-3933-4c58-a53a-a5bc7e7e3ac0" />

## 상품 변경 이벤트 흐름
<img width="500" height="626" alt="상품변경" src="https://github.com/user-attachments/assets/d57b26b1-1952-42c2-adae-8ab471863bc0" />

## 상품 좋아요 이벤트 흐름
<img width="1514" height="814" alt="스크린샷 2025-09-05 오후 6 07 05" src="https://github.com/user-attachments/assets/4e113425-6363-4b88-9e53-8622efffd0c0" />

## 주문/결제 이벤트 흐름
<img width="1422" height="863" alt="주문결제" src="https://github.com/user-attachments/assets/97890d4d-09d5-404e-a0bc-5d9f502ae117" />

## 💬 Review Points
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
-->

## 1. 이벤트 스키마/버전 관리 
- 현재 이벤트 스키마를 아래와 같이 설계했습니다.

```kotlin
class Event<T : EventPayload>(
    val eventId: String,
    val eventType: EventType,
    val payload: T,
)
```
- 혹시 이 스키마에 추가되면 좋은 필드가 있을까요? (ex: version, traceId와 같은 공통 메타데이터 등등..?)
- 추가로 멘토링 때 말씀해주신 버저닝(version) 전략을 적용하려고 하는데,
컨슈머 쪽에서 이 version 값을 최신 이벤트 판단이나 중복/역행 이벤트 처리에 어떻게 활용하는 게 좋을지 아직 감이 오지 않는데 이 부분에 대해서 조금 더 설명 부탁드려도 될까요?

## 2. Topic / Partition 설계
- 현재 토픽, 컨슈머 그룹을 다음과 같이 설계했습니다.

```kotlin
class Topic {
    companion object {
        const val PRODUCT_V1_CHANGED = "product.v1.changed"
        const val PRODUCT_V1_STOCK_ADJUSTED = "product.v1.stock-adjusted"
        const val PRODUCT_V1_STOCK_SOLD_OUT = "product.v1.stock-sold-out"
        const val PRODUCT_V1_LIKE_CHANGED = "product.v1.like-changed"
        const val PRODUCT_V1_VIEWED = "product.v1.viewed"

        // DLT
        const val PRODUCT_V1_CHANGED_DLT = "product.v1.changed.dlt"
        const val PRODUCT_V1_STOCK_ADJUSTED_DLT = "product.v1.stock-adjusted.dlt"
        const val PRODUCT_V1_STOCK_SOLD_OUT_DLT = "product.v1.stock-sold-out.dlt"
        const val PRODUCT_V1_LIKE_CHANGED_DLT = "product.v1.like-changed.dlt"
        const val PRODUCT_V1_VIEWED_DLT = "product.v1.viewed.dlt"
    }
}
class Group {
    companion object {
        const val CATALOG_EVENTS = "catalog-events-consumer"
        const val METRICS_EVENTS = "metrics-events-consumer"
        const val AUDIT_LOG_EVENTS = "audit-log-events-consumer"

        // DLT
        const val DLT_EVENTS = "dlt-events-consumer"
    }
}

// 파티션 키
kafkaTemplate.send(
	Topic.PRODUCT_V1_VIEWED,
	 productViewedEvent.productId.toString(), // productId 파티션 키 설정
	 event.toJson()
)
```
### 토픽 설계 관련 질문
- 현재는 `product.v1.*` 형태로 이벤트 타입별 토픽을 생성하고, 컨슈머 그룹은 `catalog-events`, `metrics-events` 등으로 구분했습니다.
- 이렇게 하면 토픽별로 목적을 명시적으로 분리할 수 있다는 장점이 있다고 생각했습니다.
- 다만, catalog-events라는 단일 토픽을 두고 eventType으로 분기하는 방식도 고려해볼 수 있을 것 같은데,
  - 제가 이벤트 타입별로 토픽을 나눈 선택이 괜찮은 접근인지 궁금합니다.
  - 멘토님께서는 실무에서 보통 토픽을 이벤트 타입별로 세분화하는지, 아니면 단일 토픽으로 관리하는지 궁금합니다.

### 파티션 키 설정 관련 질문
- 현재 파티션 키를 productId로 설정하여 상품 단위 순서 보장을 하도록 설계했습니다.
- 다만 인기 상품의 경우 특정 파티션에 이벤트가 몰려 파티션 핫스팟 문제가 발생할 수 있을 것 같다고 생각했습니다.
- 멘토님께서는 실무에서는 이런 경우 어떤 전략을 사용하는지 궁금합니다.

## 3. 실패/재처리 전략(DLT)
- 현재 컨슈머에서 메시지 처리 실패 시 다음과 같은 전략으로 구현했습니다.
- 재시도 + DLT 발행
  - DefaultErrorHandler를 사용해 최대 3회 재시도 후 최종 실패 시 .dlt 토픽으로 발행
  - DLT로 간 메시지는 이후 관리자가 직접 확인 후 수동으로 처리하는 방식으로 설계했습니다.
- 예외 유형별 재처리 여부 분리
  - TimeoutException, RetriableException 등 네트워크/일시적 장애는 재시도 가능 예외로 설정
  - 역직렬화 오류, 무결성 제약 위반 등은 재시도 불가능 예외로 설정했습니다.

```kotlin
 @Bean
fun errorHandler(kafkaTemplate: KafkaTemplate<Any, Any>): DefaultErrorHandler {
	// 재시도 + DLT 발행
    val recoverer = DeadLetterPublishingRecoverer(kafkaTemplate) { r, e ->
        TopicPartition("${r.topic()}.dlt", r.partition())
    }
    val handler = DefaultErrorHandler(recoverer, FixedBackOff(100L, 3L))

	// 재시도 처리 예외 클래스 목록
    handler.addRetryableExceptions(
        RetriableException::class.java,
        TimeoutException::class.java,
        NetworkException::class.java,
        QueryTimeoutException::class.java,
        SocketTimeoutException::class.java,
        ConnectException::class.java,
        IOException::class.java,
    )
	// 재시도 하지 않을 예외 클래스 목록
    handler.addNotRetryableExceptions(
        JsonProcessingException::class.java,
        DeserializationException::class.java,
        SerializationException::class.java,
        IllegalArgumentException::class.java,
        DataIntegrityViolationException::class.java,
        DuplicateKeyException::class.java,
    )
    return handler
}
```

### 실무에서 재처리 전략 질문
- 지난 주 레질리언스와 비슷하게 예외 유형에 따라 재시도 여부를 구분했는데, 실무에서도 이렇게 예외별 재처리 여부를 명시적으로 나눠서 운영하시나요? 아니면 재처리를 하지 않는 방식으로 운영하시나요?

### DLT 활용 여부 질문
- 멘토링 떄 실무에서는 DLT를 잘 활용하지 않으신다고 들었는데, 그렇다면 실패 메세지는 어떻게 관리하시는지 궁금합니다. 

## 4. Producer At Least Once 충족
- 현재 프로듀서에서 메시지 발행 실패 시 DLT로 메시지를 발행하도록 설정했습니다.
- 그런데 At-Least-Once 보장을 위해서는 단순히 **메시지를 발행했다**가 아니라, **의도한 컨슈머가 해당 메시지를 실제로 수신하고 처리했는가**가 더 중요하다고 생각했습니다.
- 이 때문에, 프로듀서에서 DLT로 우회 발행하는 방식은 At-Least-Once 보장을 충족하지 않는다고 판단했습니다.
- 결국 이 문제를 해결하기 위해서는 Outbox 패턴을 사용하는 것이 가장 적절한 방법이라고 생각하는데, 멘토님께서는 이에 대해 어떻게 생각하시는지 궁금합니다.

## 5. 이벤트 처리 시 `version` 또는 `updated_at` 기준 최신 이벤트만 반영해야 하는 케이스
<img width="500" height="101" alt="스크린샷 2025-09-05 오후 5 57 29" src="https://github.com/user-attachments/assets/0318c82a-9360-4fe9-83a0-8770fb3ab171" />

- 요구사항에서 `version` 또는 `updated_at` 기준으로 최신 이벤트만 반영이라는 부분이 있어, 어떤 케이스에서 이 로직을 적용해야 하는지 고민해봤습니다.

### 증감(Δ) 연산 기반 집계 → 순서 무관
- 예를 들어 상품 좋아요 수를 처리할 때, 이벤트마다 +1 또는 -1 식으로 증감 연산을 적용한다면 순서가 보장되지 않아도 최종 결과는 동일하다고 생각했습니다.

```sql
# 상품 좋아요 등록 집계 정보 반영
UPDATE product_metrics
SET like_count = like_count + 1
WHERE product_id = :productId
AND metric_date = :metricDate

# 상품 좋아요 취소 집계 정보 반영
UPDATE product_metrics
SET like_count = like_count - 1
WHERE product_id = :productId
AND metric_date = :metricDate
```

### 최종 값(=) 덮어쓰기 기반 집계 → 순서 중요
- 반면, 좋아요 등록/취소 이벤트마다 최종 like_count 값을 직접 세팅하는 방식이라면 이벤트 순서가 어긋났을 때 오래된 값으로 최신 값을 덮어쓸 위험이 있다고 생각했습니다.

```sql
# 상품 좋아요 등록/취소 집계 정보 반영
UPDATE product_metrics
SET like_count = :after_like_count
WHERE product_id = :productId
AND metric_date = :metricDate
```

- 제가 이해한 것처럼 증감 연산 기반 집계는 순서와 상관없이 안전하다고 봐도 될까요?
- 최종 값(=) 덮어쓰기 방식을 사용하는 경우라면 `version` 또는 `updated_at`을 반드시 비교해 최신 이벤트만 반영하는 게 맞을까요?
- 혹시 이 외에도 `version` 또는 `updated_at` 기준 반영이 필요한 케이스가 있을까요?
- 그리고 `version` 또는 `updated_at`을 활용해서 어떻게 최신 이벤트만 처리하는지에 대해 조금 감이 오지 않는데 , 혹시 이 부분에 대해 예시를 들어 설명해주실 수 있을까요?


## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->
### 🎾 Producer

- [x]  도메인(애플리케이션) 이벤트 설계
- [x]  Producer 앱에서 도메인 이벤트 발행 (catalog-events, order-events, 등)
- [x]  **PartitionKey** 기반의 이벤트 순서 보장
- [x]  메세지 발행이 실패했을 경우에 대해 고민해보기

### ⚾ Consumer

- [x]  Consumer 앱에서 3종 처리 (Audit Log / Cache Evict / Metrics 집계)
- [x]  `event_handled` 테이블을 통한 멱등 처리 구현
- [x]  재고 소진 시 상품 캐시 삭제
- [x]  중복 메세지 재전송 테스트 → 최종 결과가 한 번만 반영되는지 확인

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->