### PR TITLE
9주차 과제 구현: What is Popularity?

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
 
     // web
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
 

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/product/ProductFacade.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/product/ProductFacade.kt
@@ -5,6 +5,7 @@ import com.loopers.domain.product.ProductService
 import com.loopers.domain.product.query.ProductQueryService
 import com.loopers.domain.product.query.ProductSearchCondition
 import com.loopers.domain.productlike.ProductLikeService
+import com.loopers.domain.productrank.ProductRankService
 import com.loopers.domain.stock.StockCommand
 import com.loopers.domain.stock.StockService
 import com.loopers.domain.user.UserService
@@ -32,6 +33,7 @@ class ProductFacade(
     private val userService: UserService,
     private val cacheRepository: CacheRepository,
     private val eventPublisher: EventPublisher,
+    private val productRankService: ProductRankService,
 ) {
 
     private val log = LoggerFactory.getLogger(ProductFacade::class.java)
@@ -55,9 +57,11 @@ class ProductFacade(
             "브랜드를 찾을 수 없습니다. ${product.brandId}",
         )
         val productLikeCount = productLikeService.getProductLikeCount(product.id)
+        // 랭킹 조회
+        val productRankByDay = productRankService.getProductRankByDay(id)
         // 상품 조회 이벤트 발행
         eventPublisher.publish(ProductViewedEvent(product.id, product.name))
-        return ProductInfo.ProductDetail.from(product, brand, productLikeCount)
+        return ProductInfo.ProductDetail.from(product, brand, productLikeCount, productRankByDay)
     }
 
     @Transactional(readOnly = true)

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/product/ProductInfo.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/product/ProductInfo.kt
@@ -41,9 +41,15 @@ class ProductInfo {
         val productStatus: ProductStatusType,
         val productPrice: Long,
         val productLikeCount: Int,
+        val productRankNumber: Long?,
     ) {
         companion object {
-            fun from(product: ProductEntity, brand: BrandEntity, productLikeCountEntity: ProductLikeCountEntity?): ProductDetail {
+            fun from(
+                product: ProductEntity,
+                brand: BrandEntity,
+                productLikeCountEntity: ProductLikeCountEntity?,
+                productRankNumber: Long?,
+            ): ProductDetail {
                 return ProductDetail(
                     product.id,
                     product.name,
@@ -51,6 +57,7 @@ class ProductInfo {
                     product.status,
                     product.price.value,
                     productLikeCountEntity?.productLikeCount ?: 0,
+                    productRankNumber,
                 )
             }
         }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/productrank/ProductRankCriteria.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/productrank/ProductRankCriteria.kt
@@ -1,0 +1,23 @@
+package com.loopers.application.productrank
+
+import com.loopers.domain.productrank.ProductRankCommand
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class ProductRankCriteria {
+    data class SearchDay(
+        val rankDate: LocalDate,
+    ) {
+        fun toCommand(offset: Long, limit: Int): ProductRankCommand.SearchDay {
+            return ProductRankCommand.SearchDay(this.rankDate, offset, limit)
+        }
+    }
+
+    data class SearchHour(
+        val rankDate: LocalDateTime,
+    ) {
+        fun toCommand(offset: Long, limit: Int): ProductRankCommand.SearchHour {
+            return ProductRankCommand.SearchHour(rankDate, offset, limit)
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/productrank/ProductRankFacade.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/productrank/ProductRankFacade.kt
@@ -1,0 +1,75 @@
+package com.loopers.application.productrank
+
+import com.loopers.domain.product.query.ProductQueryService
+import com.loopers.domain.productrank.ProductRankService
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Component
+
+@Component
+class ProductRankFacade(
+    private val productRankService: ProductRankService,
+    private val productQueryService: ProductQueryService,
+) {
+
+    private val log = LoggerFactory.getLogger(ProductRankFacade::class.java)
+
+    fun getProductRanksByDay(criteria: ProductRankCriteria.SearchDay, pageable: Pageable): Page<ProductRankInfo.ProductRankList> {
+        log.info("[ProductRankFacade.getProductRanksByDay] criteria: {}, pageable: {}", criteria, pageable)
+        val productRankMap = productRankService.getProductRankIdsByDay(criteria.toCommand(pageable.offset, pageable.pageSize))
+
+        if (productRankMap.isEmpty()) {
+            return PageImpl(emptyList(), pageable, 0)
+        }
+
+        val products = productQueryService.getProductsByIds(productRankMap.keys.map { it.toLong() }.toList())
+            ?: emptyList()
+        // 랭크 정보 추가
+        val productRanks = products
+            .map {
+                ProductRankInfo.ProductRankList.from(
+                    it,
+                    productRankMap[it.id.toString()]?.rank,
+                    productRankMap[it.id.toString()]?.score,
+                )
+            }
+            .sortedBy { it.rankNumber }
+            .toList()
+        // 총 개수 조회
+        val productRankTotalCount = productRankService.getProductRankTotalCountByDay(criteria.rankDate)
+
+        return PageImpl(productRanks, pageable, productRankTotalCount)
+    }
+
+    fun getProductRanksByHour(
+        criteria: ProductRankCriteria.SearchHour,
+        pageable: Pageable,
+    ): Page<ProductRankInfo.ProductRankList> {
+        log.info("[ProductRankFacade.getProductRanksByHour] criteria: {}, pageable: {}", criteria, pageable)
+        val productRankMap = productRankService.getProductRankIdsByHour(criteria.toCommand(pageable.offset, pageable.pageSize))
+
+        if (productRankMap.isEmpty()) {
+            return PageImpl(emptyList(), pageable, 0)
+        }
+
+        val products = productQueryService.getProductsByIds(productRankMap.keys.map { it.toLong() }.toList())
+            ?: emptyList()
+        // 랭크 정보 추가
+        val productRanks = products
+            .map {
+                ProductRankInfo.ProductRankList.from(
+                    it,
+                    productRankMap[it.id.toString()]?.rank,
+                    productRankMap[it.id.toString()]?.score,
+                )
+            }
+            .sortedBy { it.rankNumber }
+            .toList()
+        // 총 개수 조회
+        val productRankTotalCount = productRankService.getProductRankTotalCountByHour(criteria.rankDate)
+
+        return PageImpl(productRanks, pageable, productRankTotalCount)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/productrank/ProductRankInfo.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/productrank/ProductRankInfo.kt
@@ -1,0 +1,35 @@
+package com.loopers.application.productrank
+
+import com.loopers.domain.product.query.ProductListViewModel
+import com.loopers.support.enums.product.ProductStatusType
+import java.time.LocalDateTime
+
+class ProductRankInfo {
+    data class ProductRankList(
+        val id: Long,
+        val productName: String,
+        val productPrice: Long,
+        val productStatus: ProductStatusType,
+        val brandName: String,
+        val productLikeCount: Int,
+        val createdAt: LocalDateTime,
+        val rankNumber: Long?,
+        val score: Double?,
+    ) {
+        companion object {
+            fun from(productListViewModel: ProductListViewModel, rankNumber: Long?, score: Double?): ProductRankList {
+                return ProductRankList(
+                    productListViewModel.id,
+                    productListViewModel.name,
+                    productListViewModel.price,
+                    productListViewModel.productStatus,
+                    productListViewModel.brandName,
+                    productListViewModel.productLikeCount,
+                    productListViewModel.createdAt.toLocalDateTime(),
+                    rankNumber,
+                    score,
+                )
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/vo/OrderItems.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/order/vo/OrderItems.kt
@@ -19,4 +19,8 @@ class OrderItems(
 
     fun toProductQuantityMap(): Map<Long, Int> =
         items.groupingBy { it.productId }.eachCount()
+
+    fun getProductPrice(productId: Long): Long {
+        return items.firstOrNull { it.productId == productId }?.amount?.value ?: 0L
+    }
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/query/ProductQueryService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/query/ProductQueryService.kt
@@ -120,4 +120,29 @@ class ProductQueryService(
 
         return PageImpl(productListViewModels, pageable, totalCount)
     }
+
+    fun getProductsByIds(productIds: List<Long>): List<ProductListViewModel>? {
+        val product = QProductEntity.productEntity
+        val brand = QBrandEntity.brandEntity
+        val likeCount = QProductLikeCountEntity.productLikeCountEntity
+
+        return queryFactory
+            .select(
+                QProductListViewModel(
+                    product.id,
+                    product.name,
+                    product.price.value,
+                    product.status,
+                    brand.name,
+                    likeCount.productLikeCount,
+                    product.createdAt,
+                ),
+            )
+            .from(product)
+            .join(brand).on(brand.id.eq(product.brandId))
+            .leftJoin(likeCount).on(product.id.eq(likeCount.productId))
+            .groupBy(product.id)
+            .where(product.id.`in`(productIds))
+            .fetch()
+    }
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/productrank/ProductRankCommand.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/productrank/ProductRankCommand.kt
@@ -1,0 +1,18 @@
+package com.loopers.domain.productrank
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class ProductRankCommand {
+    data class SearchDay(
+        val rankDate: LocalDate,
+        val offset: Long,
+        val limit: Int,
+    )
+
+    data class SearchHour(
+        val rankDate: LocalDateTime,
+        val offset: Long,
+        val limit: Int,
+    )
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/productrank/ProductRankService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/productrank/ProductRankService.kt
@@ -1,0 +1,45 @@
+package com.loopers.domain.productrank
+
+import com.loopers.support.cache.CacheRepository
+import com.loopers.support.cache.dto.ScoreRankDto
+import com.loopers.support.cache.productrank.ProductRankCacheKeyGenerator
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Service
+class ProductRankService(
+    private val cacheRepository: CacheRepository,
+) {
+
+    fun getProductRankIdsByDay(command: ProductRankCommand.SearchDay): Map<String, ScoreRankDto> {
+        return cacheRepository.findTopRankByScoreDesc(
+            ProductRankCacheKeyGenerator.generate(command.rankDate),
+            command.offset,
+            command.limit,
+        )
+    }
+
+    fun getProductRankTotalCountByDay(rankDate: LocalDate): Long {
+        return cacheRepository.getTotalCount(ProductRankCacheKeyGenerator.generate(rankDate))
+    }
+
+    fun getProductRankByDay(productId: Long): Long? {
+        return cacheRepository.findRank(
+            ProductRankCacheKeyGenerator.generate(LocalDate.now()),
+            productId.toString(),
+        )
+    }
+
+    fun getProductRankIdsByHour(command: ProductRankCommand.SearchHour): Map<String, ScoreRankDto> {
+        return cacheRepository.findTopRankByScoreDesc(
+            ProductRankCacheKeyGenerator.generate(command.rankDate),
+            command.offset,
+            command.limit,
+        )
+    }
+
+    fun getProductRankTotalCountByHour(rankDate: LocalDateTime): Long {
+        return cacheRepository.getTotalCount(ProductRankCacheKeyGenerator.generate(rankDate))
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/product/ProductV1Dto.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/product/ProductV1Dto.kt
@@ -74,6 +74,7 @@ class ProductV1Dto {
         val productStatus: ProductStatusType,
         val productPrice: Long,
         val productLikeCount: Int,
+        val productRankNumber: Long?,
     ) {
         companion object {
             fun from(productDetail: ProductInfo.ProductDetail): ProductDetailResponse {
@@ -84,6 +85,7 @@ class ProductV1Dto {
                     productDetail.productStatus,
                     productDetail.productPrice,
                     productDetail.productLikeCount,
+                    productDetail.productRankNumber,
                 )
             }
         }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/productrank/ProductRankV1ApiSpec.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/productrank/ProductRankV1ApiSpec.kt
@@ -1,0 +1,19 @@
+package com.loopers.interfaces.api.productrank
+
+import com.loopers.interfaces.api.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface ProductRankV1ApiSpec {
+    @Operation(
+        summary = "상품 랭킹 목록 조회",
+        description = "요청한 정보로 상품 랭킹 목록을 조회합니다.",
+    )
+    fun getProductRanks(
+        @Schema(name = "상품 랭킹 검색 조건", description = "상품 랭킹을 검색하기 위한 조건")
+        request: ProductRankV1Dto.Request,
+        pageable: Pageable,
+    ): ApiResponse<Page<ProductRankV1Dto.ProductRankListResponse>>
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/productrank/ProductRankV1Controller.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/productrank/ProductRankV1Controller.kt
@@ -1,0 +1,26 @@
+package com.loopers.interfaces.api.productrank
+
+import com.loopers.application.productrank.ProductRankFacade
+import com.loopers.interfaces.api.ApiResponse
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/rankings")
+class ProductRankV1Controller(
+    private val productRankFacade: ProductRankFacade,
+) : ProductRankV1ApiSpec {
+
+    @GetMapping("")
+    override fun getProductRanks(
+        request: ProductRankV1Dto.Request,
+        pageable: Pageable,
+    ): ApiResponse<Page<ProductRankV1Dto.ProductRankListResponse>> {
+        return productRankFacade.getProductRanksByDay(request.toCriteria(), pageable)
+            .map { ProductRankV1Dto.ProductRankListResponse.from(it) }
+            .let { ApiResponse.success(it) }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/productrank/ProductRankV1Dto.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/productrank/ProductRankV1Dto.kt
@@ -1,0 +1,45 @@
+package com.loopers.interfaces.api.productrank
+
+import com.loopers.application.productrank.ProductRankCriteria
+import com.loopers.application.productrank.ProductRankInfo
+import com.loopers.support.enums.product.ProductStatusType
+import org.springframework.format.annotation.DateTimeFormat
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class ProductRankV1Dto {
+    data class Request(
+        @field:DateTimeFormat(pattern = "yyyy-MM-dd")
+        val rankDate: LocalDate,
+    ) {
+        fun toCriteria(): ProductRankCriteria.SearchDay {
+            return ProductRankCriteria.SearchDay(rankDate)
+        }
+    }
+
+    data class ProductRankListResponse(
+        val id: Long,
+        val productName: String,
+        val productPrice: Long,
+        val productStatus: ProductStatusType,
+        val brandName: String,
+        val productLikeCount: Int,
+        val createdAt: LocalDateTime,
+        val rankNumber: Long? = 0L,
+    ) {
+        companion object {
+            fun from(productRankList: ProductRankInfo.ProductRankList): ProductRankListResponse {
+                return ProductRankListResponse(
+                    productRankList.id,
+                    productRankList.productName,
+                    productRankList.productPrice,
+                    productRankList.productStatus,
+                    productRankList.brandName,
+                    productRankList.productLikeCount,
+                    productRankList.createdAt,
+                    productRankList.rankNumber,
+                )
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/listener/order/OrderEventListener.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/listener/order/OrderEventListener.kt
@@ -77,7 +77,8 @@ class OrderEventListener(
         val order = orderService.findWithItemsByOrderKey(event.orderKey)
             ?: throw IllegalStateException("주문 정보를 찾을 수 없습니다. orderKey: ${event.orderKey}")
         order.orderItems.toProductQuantityMap().forEach { productQuantity ->
-            stockEventPublisher.publish(StockAdjustedEvent(productQuantity.key, productQuantity.value))
+            val amount = order.orderItems.getProductPrice(productQuantity.key)
+            stockEventPublisher.publish(StockAdjustedEvent(productQuantity.key, productQuantity.value, amount))
         }
         val stocks = stockService.getStocksByProductIds(order.orderItems.toProductQuantityMap().map { it.key })
         stocks.filter { it.isSoldOut() }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/web/productrank/ProductRankController.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/web/productrank/ProductRankController.kt
@@ -1,0 +1,74 @@
+package com.loopers.interfaces.web.productrank
+
+import com.loopers.application.productrank.ProductRankCriteria
+import com.loopers.application.productrank.ProductRankFacade
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Controller
+@RequestMapping("/rankings")
+class ProductRankController(
+    private val productRankFacade: ProductRankFacade,
+) {
+
+    @GetMapping("daily")
+    fun dailyRanking(model: Model): String {
+        val today = LocalDate.now()
+        val products = productRankFacade.getProductRanksByDay(
+            ProductRankCriteria.SearchDay(
+                today,
+            ),
+            PageRequest.of(0, 20),
+        )
+        model.addAttribute("rankingDate", today)
+        model.addAttribute("items", products.content)
+        return "product-rank/daily"
+    }
+
+    @GetMapping("daily-refresh")
+    fun dailyRankingRefresh(model: Model): String {
+        val today = LocalDate.now()
+        val products = productRankFacade.getProductRanksByDay(
+            ProductRankCriteria.SearchDay(
+                today,
+            ),
+            PageRequest.of(0, 20),
+        )
+        model.addAttribute("rankingDate", today)
+        model.addAttribute("items", products.content)
+        return "product-rank/daily-list :: product-ranking-auto"
+    }
+
+    @GetMapping("hourly")
+    fun hourlyRanking(model: Model): String {
+        val today = LocalDateTime.now()
+        val products = productRankFacade.getProductRanksByHour(
+            ProductRankCriteria.SearchHour(
+                today,
+            ),
+            PageRequest.of(0, 20),
+        )
+        model.addAttribute("rankingDate", today)
+        model.addAttribute("items", products.content)
+        return "product-rank/hourly"
+    }
+
+    @GetMapping("hourly-refresh")
+    fun hourlyRankingRefresh(model: Model): String {
+        val today = LocalDateTime.now()
+        val products = productRankFacade.getProductRanksByHour(
+            ProductRankCriteria.SearchHour(
+                today,
+            ),
+            PageRequest.of(0, 20),
+        )
+        model.addAttribute("rankingDate", today)
+        model.addAttribute("items", products.content)
+        return "product-rank/hourly-list :: product-ranking-auto"
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/support/cache/CacheKey.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/support/cache/CacheKey.kt
@@ -7,6 +7,7 @@ object CacheNames {
     const val PRODUCT_DETAIL_V1 = "product:detail:v1:"
     const val PRODUCT_LIKE_COUNT_V1 = "product:like-count:v1:"
     const val BRAND_DETAIL_V1 = "brand:detail:v1:"
+    const val PRODUCT_RANK_ALL_KEY_PREFIX = "ranking:all:"
 }
 
 class CacheKey(

--- a/apps/commerce-api/src/main/kotlin/com/loopers/support/cache/CacheRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/support/cache/CacheRepository.kt
@@ -1,9 +1,17 @@
 package com.loopers.support.cache
 
+import com.loopers.support.cache.dto.ScoreRankDto
+
 interface CacheRepository {
     fun <T> get(cacheKey: CacheKey, clazz: Class<T>): T?
 
     fun <T> set(cacheKey: CacheKey, value: T)
 
     fun evict(key: String)
+
+    fun findTopRankByScoreDesc(cacheKey: CacheKey, offset: Long, size: Int): Map<String, ScoreRankDto>
+
+    fun findRank(cacheKey: CacheKey, item: String): Long?
+
+    fun getTotalCount(cacheKey: CacheKey): Long
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/support/cache/dto/ScoreRankDto.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/support/cache/dto/ScoreRankDto.kt
@@ -1,0 +1,6 @@
+package com.loopers.support.cache.dto
+
+class ScoreRankDto(
+    val score: Double,
+    val rank: Long,
+)

--- a/apps/commerce-api/src/main/kotlin/com/loopers/support/cache/productrank/ProductRankCacheKeyGenerator.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/support/cache/productrank/ProductRankCacheKeyGenerator.kt
@@ -1,0 +1,33 @@
+package com.loopers.support.cache.productrank
+
+import com.loopers.support.cache.CacheKey
+import com.loopers.support.cache.CacheNames
+import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+object ProductRankCacheKeyGenerator {
+
+    fun generate(date: LocalDateTime): CacheKey {
+        val formatter = DateTimeFormatter.ofPattern("yyyyMMddHH")
+        val formattedDate = formatter.format(date)
+        return CacheKey(
+            CacheNames.PRODUCT_RANK_ALL_KEY_PREFIX,
+            formattedDate,
+            // ttl 2시간 설정
+            Duration.ofHours(2),
+        )
+    }
+
+    fun generate(date: LocalDate): CacheKey {
+        val formatter = DateTimeFormatter.ofPattern("yyyyMMdd")
+        val formattedDate = formatter.format(date)
+        return CacheKey(
+            CacheNames.PRODUCT_RANK_ALL_KEY_PREFIX,
+            formattedDate,
+            // ttl 2일로 설정
+            Duration.ofDays(2),
+        )
+    }
+}

--- a/apps/commerce-api/src/main/resources/templates/product-rank/daily-list.html
+++ b/apps/commerce-api/src/main/resources/templates/product-rank/daily-list.html
@@ -1,0 +1,105 @@
+<html lang="en"
+      xmlns:th="http://www.thymeleaf.org">
+<body>
+<div id="ranking-host"
+     th:fragment="product-ranking-auto(rankingDate, items)"
+     class="relative"
+     th:attr="hx-get=|/rankings/daily-refresh|"
+     hx-trigger="load once, every 1s"
+     hx-target="#ranking-root"
+     hx-select="#ranking-root"
+     hx-swap="outerHTML"
+     hx-history="false"
+     hx-indicator="#ranking-loading-indicator">
+
+    <!-- 로딩 인디케이터 (HTMX가 요청중일 때 표시) -->
+    <div id="ranking-loading-indicator"
+         class="hidden absolute -top-10 right-0 htmx-indicator">
+        <div class="flex items-center text-gray-700">
+            <svg class="animate-spin -ml-1 mr-3 h-5 w-5 text-gray-800" xmlns="http://www.w3.org/2000/svg" fill="none"
+                 viewBox="0 0 24 24" aria-hidden="true">
+                <circle class="opacity-25" cx="12" cy="12" r="10"
+                        stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0
+                 3.042 1.135 5.824 3 7.938l3-2.647z"/>
+            </svg>
+            <span class="text-sm">업데이트 중…</span>
+        </div>
+    </div>
+
+    <!-- 실제 콘텐츠 조각 삽입 -->
+    <div th:replace="~{this :: product-ranking-content(rankingDate=${rankingDate}, items=${items})}"></div>
+</div>
+
+<!-- 2) Table Content Fragment -->
+<div id="ranking-root"
+     th:fragment="product-ranking-content(rankingDate, items)">
+    <div class="bg-white shadow-lg rounded-lg p-6">
+        <div class="flex items-center justify-between mb-4">
+            <div class="text-gray-700">
+                <span class="font-semibold">기준일:</span>
+                <span th:text="${rankingDate}">2025-09-11</span>
+            </div>
+        </div>
+
+        <div class="overflow-x-auto">
+            <table class="table-auto w-full border-collapse border border-gray-200">
+                <thead class="bg-gray-50">
+                <tr>
+                    <th class="border border-gray-200 px-4 py-3 text-center w-16">순위</th>
+                    <th class="border border-gray-200 px-4 py-3 text-left">랭킹</th>
+                    <th class="border border-gray-200 px-4 py-3 text-center">상품명</th>
+                    <th class="border border-gray-200 px-4 py-3 text-center">가격</th>
+                    <th class="border border-gray-200 px-4 py-3 text-center">좋아요수</th>
+                    <th class="border border-gray-200 px-4 py-3 text-center">score</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="product, iter : ${items}"
+                    class="hover:bg-gray-50">
+                    <td class="border border-gray-200 px-4 py-2 text-center font-medium"
+                        th:text="${iter.index + 1}">1
+                    </td>
+                    <td class="border border-gray-200 px-4 py-2 text-center"
+                        th:text="${product.rankNumber}">랭킹
+                    </td>
+                    <td class="border border-gray-200 px-4 py-2"
+                        th:text="${product.productName}">상품명
+                    </td>
+                    <td class="border border-gray-200 px-4 py-2 text-center"
+                        th:text="${product.productPrice}">0
+                    </td>
+                    <td class="border border-gray-200 px-4 py-2 text-center"
+                        th:text="${product.productLikeCount}">0
+                    </td>
+                    <td class="border border-gray-200 px-4 py-2 text-center"
+                        th:text="${product.score}">0
+                    </td>
+                </tr>
+
+                <!-- 빈 목록 처리 -->
+                <tr th:if="${#lists.isEmpty(items)}">
+                    <td colspan="6" class="border border-gray-200 px-4 py-8 text-center text-gray-500">
+                        표시할 랭킹 데이터가 없습니다.
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <!-- 수동 새로고침 버튼(옵션) -->
+        <div class="mt-4 flex justify-end">
+            <button class="px-4 py-2 rounded-lg border text-sm hover:bg-gray-50"
+                    th:attr="hx-get=|/rankings/daily-refresh|"
+                    hx-target="#ranking-root"
+                    hx-select="#ranking-root"
+                    hx-swap="outerHTML"
+                    hx-indicator="#ranking-loading-indicator">
+                수동 새로고침
+            </button>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/apps/commerce-api/src/main/resources/templates/product-rank/daily.html
+++ b/apps/commerce-api/src/main/resources/templates/product-rank/daily.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8"/>
+    <title>상품 랭킹 TOP 20</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/htmx.org@1.7.0"
+            integrity="sha384-EzBXYPt0/T6gxNp0nuPtLkmRpmDBbjg6WmCUZRLXBBwYYmwAUxzlSGej0ARHX0Bo"
+            crossorigin="anonymous" defer></script>
+</head>
+
+<body class="bg-gray-100 min-h-screen">
+<main class="max-w-6xl mx-auto p-6">
+    <h1 class="text-2xl font-bold text-gray-800 mb-4">상품 랭킹 TOP 20 (Daily)</h1>
+
+    <!-- 자동 새로고침 래퍼: 최초 로드 + 10초 주기 -->
+    <div th:replace="~{product-rank/daily-list :: product-ranking-auto(rankingDate=${rankingDate}, items=${items})}"></div>
+</main>
+
+</body>
+</html>

--- a/apps/commerce-api/src/main/resources/templates/product-rank/hourly-list.html
+++ b/apps/commerce-api/src/main/resources/templates/product-rank/hourly-list.html
@@ -1,0 +1,105 @@
+<html lang="en"
+      xmlns:th="http://www.thymeleaf.org">
+<body>
+<div id="ranking-host"
+     th:fragment="product-ranking-auto(rankingDate, items)"
+     class="relative"
+     th:attr="hx-get=|/rankings/hourly-refresh|"
+     hx-trigger="load once, every 1s"
+     hx-target="#ranking-root"
+     hx-select="#ranking-root"
+     hx-swap="outerHTML"
+     hx-history="false"
+     hx-indicator="#ranking-loading-indicator">
+
+    <!-- 로딩 인디케이터 (HTMX가 요청중일 때 표시) -->
+    <div id="ranking-loading-indicator"
+         class="hidden absolute -top-10 right-0 htmx-indicator">
+        <div class="flex items-center text-gray-700">
+            <svg class="animate-spin -ml-1 mr-3 h-5 w-5 text-gray-800" xmlns="http://www.w3.org/2000/svg" fill="none"
+                 viewBox="0 0 24 24" aria-hidden="true">
+                <circle class="opacity-25" cx="12" cy="12" r="10"
+                        stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0
+                 3.042 1.135 5.824 3 7.938l3-2.647z"/>
+            </svg>
+            <span class="text-sm">업데이트 중…</span>
+        </div>
+    </div>
+
+    <!-- 실제 콘텐츠 조각 삽입 -->
+    <div th:replace="~{this :: product-ranking-content(rankingDate=${rankingDate}, items=${items})}"></div>
+</div>
+
+<!-- 2) Table Content Fragment -->
+<div id="ranking-root"
+     th:fragment="product-ranking-content(rankingDate, items)">
+    <div class="bg-white shadow-lg rounded-lg p-6">
+        <div class="flex items-center justify-between mb-4">
+            <div class="text-gray-700">
+                <span class="font-semibold">기준일:</span>
+                <span th:text="${rankingDate}">2025-09-11</span>
+            </div>
+        </div>
+
+        <div class="overflow-x-auto">
+            <table class="table-auto w-full border-collapse border border-gray-200">
+                <thead class="bg-gray-50">
+                <tr>
+                    <th class="border border-gray-200 px-4 py-3 text-center w-16">순위</th>
+                    <th class="border border-gray-200 px-4 py-3 text-left">랭킹</th>
+                    <th class="border border-gray-200 px-4 py-3 text-center">상품명</th>
+                    <th class="border border-gray-200 px-4 py-3 text-center">가격</th>
+                    <th class="border border-gray-200 px-4 py-3 text-center">좋아요수</th>
+                    <th class="border border-gray-200 px-4 py-3 text-center">score</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="product, iter : ${items}"
+                    class="hover:bg-gray-50">
+                    <td class="border border-gray-200 px-4 py-2 text-center font-medium"
+                        th:text="${iter.index + 1}">1
+                    </td>
+                    <td class="border border-gray-200 px-4 py-2 text-center"
+                        th:text="${product.rankNumber}">랭킹
+                    </td>
+                    <td class="border border-gray-200 px-4 py-2"
+                        th:text="${product.productName}">상품명
+                    </td>
+                    <td class="border border-gray-200 px-4 py-2 text-center"
+                        th:text="${product.productPrice}">0
+                    </td>
+                    <td class="border border-gray-200 px-4 py-2 text-center"
+                        th:text="${product.productLikeCount}">0
+                    </td>
+                    <td class="border border-gray-200 px-4 py-2 text-center"
+                        th:text="${product.score}">0
+                    </td>
+                </tr>
+
+                <!-- 빈 목록 처리 -->
+                <tr th:if="${#lists.isEmpty(items)}">
+                    <td colspan="6" class="border border-gray-200 px-4 py-8 text-center text-gray-500">
+                        표시할 랭킹 데이터가 없습니다.
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <!-- 수동 새로고침 버튼(옵션) -->
+        <div class="mt-4 flex justify-end">
+            <button class="px-4 py-2 rounded-lg border text-sm hover:bg-gray-50"
+                    th:attr="hx-get=|/rankings/hourly-refresh|"
+                    hx-target="#ranking-root"
+                    hx-select="#ranking-root"
+                    hx-swap="outerHTML"
+                    hx-indicator="#ranking-loading-indicator">
+                수동 새로고침
+            </button>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/apps/commerce-api/src/main/resources/templates/product-rank/hourly.html
+++ b/apps/commerce-api/src/main/resources/templates/product-rank/hourly.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8"/>
+    <title>상품 랭킹 TOP 20</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/htmx.org@1.7.0"
+            integrity="sha384-EzBXYPt0/T6gxNp0nuPtLkmRpmDBbjg6WmCUZRLXBBwYYmwAUxzlSGej0ARHX0Bo"
+            crossorigin="anonymous" defer></script>
+</head>
+
+<body class="bg-gray-100 min-h-screen">
+<main class="max-w-6xl mx-auto p-6">
+    <h1 class="text-2xl font-bold text-gray-800 mb-4">상품 랭킹 TOP 20 (Hourly)</h1>
+
+    <!-- 자동 새로고침 래퍼: 최초 로드 + 10초 주기 -->
+    <div th:replace="~{product-rank/hourly-list :: product-ranking-auto(rankingDate=${rankingDate}, items=${items})}"></div>
+</main>
+
+</body>
+</html>

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/CommerceStreamerApplication.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/CommerceStreamerApplication.kt
@@ -3,14 +3,17 @@ package com.loopers
 import jakarta.annotation.PostConstruct
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
+import java.util.TimeZone
 
+@EnableScheduling
 @SpringBootApplication
 class CommerceStreamerApplication {
 
     @PostConstruct
     fun started() {
         // set timezone
-        java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Asia/Seoul"))
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))
     }
 }
 

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/ProductRankCarryOverService.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/ProductRankCarryOverService.kt
@@ -1,0 +1,55 @@
+package com.loopers.domain.productrank
+
+import com.loopers.support.cache.CacheRepository
+import com.loopers.support.cache.productrank.ProductRankCacheKeyGenerator
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.DefaultTypedTuple
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Service
+class ProductRankCarryOverService(
+    private val cacheRepository: CacheRepository,
+) {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    fun carryOverTomorrowRank(topN: Int, normalize: Double) {
+        log.info("[ProductRankCarryOverService.carryOverTomorrowRank] topN: {}, normalize: {}", topN, normalize)
+        val today = LocalDate.now()
+        val tomorrow = today.plusDays(1)
+
+        val productRanksWithScore = cacheRepository.findTopRankByScoreDesc(ProductRankCacheKeyGenerator.generate(today), 0, topN)
+
+        val normalizedTuples = productRanksWithScore.map { (productId, score) ->
+            DefaultTypedTuple(productId, score * normalize)
+        }.toSet()
+
+        if (normalizedTuples.isEmpty()) {
+            log.info("[ProductRankCarryOverService.carryOverTomorrowRank] 상품 랭킹이 비어있습니다. 오늘 날짜: {}", today)
+            return
+        }
+
+        cacheRepository.zAddAll(ProductRankCacheKeyGenerator.generate(tomorrow), normalizedTuples)
+    }
+
+    fun carryOverNextHourRank(topN: Int, normalize: Double) {
+        log.info("[ProductRankCarryOverService.carryOverNextHourRank] topN: {}, normalize: {}", topN, normalize)
+        val now = LocalDateTime.now()
+        val nextHour = now.plusHours(1)
+
+        val productRanksWithScore = cacheRepository.findTopRankByScoreDesc(ProductRankCacheKeyGenerator.generate(now), 0, topN)
+
+        val normalizedTuples = productRanksWithScore.map { (productId, score) ->
+            DefaultTypedTuple(productId, score * normalize)
+        }.toSet()
+
+        if (normalizedTuples.isEmpty()) {
+            log.info("[ProductRankCarryOverService.carryOverNextHourRank] 상품 랭킹이 비어있습니다. 현재 시간: {}", now)
+            return
+        }
+
+        cacheRepository.zAddAll(ProductRankCacheKeyGenerator.generate(nextHour), normalizedTuples)
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/ProductRankDaily.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/ProductRankDaily.kt
@@ -1,0 +1,14 @@
+package com.loopers.domain.productrank
+
+import com.loopers.domain.BaseEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "product_rank_daily")
+class ProductRankDaily(
+    val productId: String,
+    val rankDate: String,
+    val rankNumber: Int,
+    val score: Double,
+) : BaseEntity()

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/ProductRankDailyRepository.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/ProductRankDailyRepository.kt
@@ -1,0 +1,5 @@
+package com.loopers.domain.productrank
+
+interface ProductRankDailyRepository {
+    fun saveAll(ranks: List<ProductRankDaily>)
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/ProductRankEventHandler.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/ProductRankEventHandler.kt
@@ -1,0 +1,11 @@
+package com.loopers.domain.productrank
+
+import com.loopers.event.EventType
+import com.loopers.event.payload.EventPayload
+import com.loopers.support.cache.CacheKey
+
+interface ProductRankEventHandler<T : EventPayload> {
+    fun handle(cacheKey: CacheKey, events: List<T>)
+
+    fun supports(eventType: EventType): Boolean
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/ProductRankEventHandlerFactory.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/ProductRankEventHandlerFactory.kt
@@ -1,0 +1,21 @@
+package com.loopers.domain.productrank
+
+import com.loopers.event.EventType
+import com.loopers.event.payload.EventPayload
+import com.loopers.support.cache.CacheKey
+import org.springframework.stereotype.Component
+
+@Component
+class ProductRankEventHandlerFactory(
+    private val handlers: List<ProductRankEventHandler<out EventPayload>>,
+) {
+    @Suppress("UNCHECKED_CAST")
+    fun <T : EventPayload> handle(cacheKey: CacheKey, eventType: EventType, events: List<T>) {
+        val handler = (
+                handlers.find { it.supports(eventType) }
+                        as? ProductRankEventHandler<T>
+                    ?: throw IllegalStateException("해당 이벤트를 처리할 핸들러가 없습니다.")
+                )
+        handler.handle(cacheKey, events)
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/ProductRankHourly.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/ProductRankHourly.kt
@@ -1,0 +1,14 @@
+package com.loopers.domain.productrank
+
+import com.loopers.domain.BaseEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "product_rank_hourly")
+class ProductRankHourly(
+    val productId: String,
+    val rankDateTime: String,
+    val rankNumber: Int,
+    val score: Double,
+) : BaseEntity()

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/ProductRankHourlyRepository.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/ProductRankHourlyRepository.kt
@@ -1,0 +1,5 @@
+package com.loopers.domain.productrank
+
+interface ProductRankHourlyRepository {
+    fun saveAll(ranks: List<ProductRankHourly>)
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/ProductRankScoreCalculator.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/ProductRankScoreCalculator.kt
@@ -1,0 +1,17 @@
+package com.loopers.domain.productrank
+
+import kotlin.math.log10
+
+object ProductRankScoreCalculator {
+    fun calculateScoreByViewCount(viewCount: Int): Double {
+        return viewCount * ProductRankScoreWeight.PRODUCT_VIEW_COUNT_WEIGHT
+    }
+
+    fun calculateScoreByLikeCount(likeCount: Int): Double {
+        return likeCount * ProductRankScoreWeight.PRODUCT_LIKE_COUNT_WEIGHT
+    }
+
+    fun calculateScoreBySalesCount(salesCount: Int, amount: Long): Double {
+        return log10((salesCount * amount) * ProductRankScoreWeight.PRODUCT_SALES_COUNT_WEIGHT)
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/ProductRankScoreWeight.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/ProductRankScoreWeight.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.productrank
+
+object ProductRankScoreWeight {
+    const val PRODUCT_VIEW_COUNT_WEIGHT: Double = 0.1 // 조회수 가중치
+    const val PRODUCT_LIKE_COUNT_WEIGHT: Double = 0.3 // 좋아요수 가중치
+    const val PRODUCT_SALES_COUNT_WEIGHT: Double = 0.7 // 판매량수 가중치
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/ProductRankService.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/ProductRankService.kt
@@ -1,0 +1,74 @@
+package com.loopers.domain.productrank
+
+import com.loopers.event.EventType
+import com.loopers.event.payload.EventPayload
+import com.loopers.support.cache.CacheKey
+import com.loopers.support.cache.CacheRepository
+import com.loopers.support.cache.productrank.ProductRankCacheKeyGenerator
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Service
+class ProductRankService(
+    private val productRankEventHandlerFactory: ProductRankEventHandlerFactory,
+    private val cacheRepository: CacheRepository,
+    private val productRankDailyRepository: ProductRankDailyRepository,
+    private val productRankHourlyRepository: ProductRankHourlyRepository,
+) {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    fun handleEvent(cacheKey: CacheKey, eventType: EventType, events: List<EventPayload>) {
+        productRankEventHandlerFactory.handle(cacheKey, eventType, events)
+    }
+
+    fun backupYesterdayProductRank(prevDate: LocalDate) {
+        log.info("[ProductRankService.backupYesterdayProductRank] prevDate: $prevDate")
+        val cacheKey = ProductRankCacheKeyGenerator.generate(prevDate)
+        val yesterdayProductRanks = cacheRepository.findTopRankByScoreDesc(
+            cacheKey,
+            0,
+            100,
+        )
+
+        val productRankDailies = mutableListOf<ProductRankDaily>()
+        yesterdayProductRanks.onEachIndexed { index, productRank ->
+            productRankDailies.add(
+                ProductRankDaily(
+                    productRank.key,
+                    cacheKey.key,
+                    index + 1,
+                    productRank.value,
+                ),
+            )
+        }
+
+        productRankDailyRepository.saveAll(productRankDailies)
+    }
+
+    fun backupPrevHourProductRank(prevHours: LocalDateTime) {
+        log.info("[ProductRankService.backupPrevHourProductRank] prevHours: $prevHours")
+        val cacheKey = ProductRankCacheKeyGenerator.generate(prevHours)
+        val prevHourProductRanks = cacheRepository.findTopRankByScoreDesc(
+            cacheKey,
+            0,
+            100,
+        )
+
+        val productRankHourlies = mutableListOf<ProductRankHourly>()
+        prevHourProductRanks.onEachIndexed { index, productRank ->
+            productRankHourlies.add(
+                ProductRankHourly(
+                    productRank.key,
+                    cacheKey.key,
+                    index + 1,
+                    productRank.value,
+                ),
+            )
+        }
+
+        productRankHourlyRepository.saveAll(productRankHourlies)
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/handler/ProductRankProductLikedEventHandler.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/handler/ProductRankProductLikedEventHandler.kt
@@ -1,0 +1,34 @@
+package com.loopers.domain.productrank.handler
+
+import com.loopers.domain.productrank.ProductRankEventHandler
+import com.loopers.domain.productrank.ProductRankScoreCalculator
+import com.loopers.event.EventType
+import com.loopers.event.payload.productlike.ProductLikedEvent
+import com.loopers.support.cache.CacheKey
+import com.loopers.support.cache.CacheRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class ProductRankProductLikedEventHandler(
+    private val cacheRepository: CacheRepository,
+) : ProductRankEventHandler<ProductLikedEvent> {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    override fun handle(cacheKey: CacheKey, events: List<ProductLikedEvent>) {
+        events.groupingBy { it.productId }.eachCount()
+            .forEach { (productId, count) ->
+                val score = ProductRankScoreCalculator.calculateScoreByLikeCount(count)
+                log.info(
+                    "[ProductRankProductLikedEventHandler.handle] productId: $productId," +
+                            " count: $count, cacheKey: $cacheKey, score: ${score * count}",
+                )
+                cacheRepository.zIncrBy(cacheKey, productId, score)
+            }
+    }
+
+    override fun supports(eventType: EventType): Boolean {
+        return EventType.PRODUCT_LIKED == eventType
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/handler/ProductRankProductUnlikedEventHandler.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/handler/ProductRankProductUnlikedEventHandler.kt
@@ -1,0 +1,34 @@
+package com.loopers.domain.productrank.handler
+
+import com.loopers.domain.productrank.ProductRankEventHandler
+import com.loopers.domain.productrank.ProductRankScoreCalculator
+import com.loopers.event.EventType
+import com.loopers.event.payload.productlike.ProductUnlikedEvent
+import com.loopers.support.cache.CacheKey
+import com.loopers.support.cache.CacheRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class ProductRankProductUnlikedEventHandler(
+    private val cacheRepository: CacheRepository,
+) : ProductRankEventHandler<ProductUnlikedEvent> {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    override fun handle(cacheKey: CacheKey, events: List<ProductUnlikedEvent>) {
+        events.groupingBy { it.productId }.eachCount()
+            .forEach { (productId, count) ->
+                val score = ProductRankScoreCalculator.calculateScoreByLikeCount(-count)
+                log.info(
+                    "[ProductRankProductUnlikedEventHandler.handle] productId: $productId," +
+                            " count: ${-count}, cacheKey: $cacheKey, score: ${score * count}",
+                )
+                cacheRepository.zIncrBy(cacheKey, productId, score)
+            }
+    }
+
+    override fun supports(eventType: EventType): Boolean {
+        return EventType.PRODUCT_UNLIKED == eventType
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/handler/ProductRankProductViewedEventHandler.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/handler/ProductRankProductViewedEventHandler.kt
@@ -1,0 +1,34 @@
+package com.loopers.domain.productrank.handler
+
+import com.loopers.domain.productrank.ProductRankEventHandler
+import com.loopers.domain.productrank.ProductRankScoreCalculator
+import com.loopers.event.EventType
+import com.loopers.event.payload.product.ProductViewedEvent
+import com.loopers.support.cache.CacheKey
+import com.loopers.support.cache.CacheRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class ProductRankProductViewedEventHandler(
+    private val cacheRepository: CacheRepository,
+) : ProductRankEventHandler<ProductViewedEvent> {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    override fun handle(cacheKey: CacheKey, events: List<ProductViewedEvent>) {
+        events.groupingBy { it.productId }.eachCount()
+            .forEach { (productId, count) ->
+                val score = ProductRankScoreCalculator.calculateScoreByViewCount(count)
+                log.info(
+                    "[ProductRankProductViewedEventHandler.handle] productId: $productId," +
+                            " count: $count, cacheKey: $cacheKey, score: ${score * count}",
+                )
+                cacheRepository.zIncrBy(cacheKey, productId, score)
+            }
+    }
+
+    override fun supports(eventType: EventType): Boolean {
+        return EventType.PRODUCT_VIEWED == eventType
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/handler/ProductRankStockAdjustedEventHandler.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/handler/ProductRankStockAdjustedEventHandler.kt
@@ -1,0 +1,35 @@
+package com.loopers.domain.productrank.handler
+
+import com.loopers.domain.productrank.ProductRankEventHandler
+import com.loopers.domain.productrank.ProductRankScoreCalculator
+import com.loopers.event.EventType
+import com.loopers.event.payload.stock.StockAdjustedEvent
+import com.loopers.support.cache.CacheKey
+import com.loopers.support.cache.CacheRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class ProductRankStockAdjustedEventHandler(
+    private val cacheRepository: CacheRepository,
+) : ProductRankEventHandler<StockAdjustedEvent> {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    override fun handle(cacheKey: CacheKey, events: List<StockAdjustedEvent>) {
+        events.groupBy { it.productId }.forEach { (productId, events) ->
+            val sumOfQuantity = events.sumOf { it.quantity }
+            val sumOfAmount = events.sumOf { it.amount }
+            val score = ProductRankScoreCalculator.calculateScoreBySalesCount(sumOfQuantity, sumOfAmount)
+            log.info(
+                "[ProductRankStockAdjustedEventHandler.handle] productId: $productId," +
+                        " sumOfQuantity: $sumOfQuantity, sumOfAmount: $sumOfAmount",
+            )
+            cacheRepository.zIncrBy(cacheKey, productId, score)
+        }
+    }
+
+    override fun supports(eventType: EventType): Boolean {
+        return EventType.PRODUCT_STOCK_ADJUSTED == eventType
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/productrank/ProductRankDailyJpaRepository.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/productrank/ProductRankDailyJpaRepository.kt
@@ -1,0 +1,6 @@
+package com.loopers.infrastructure.productrank
+
+import com.loopers.domain.productrank.ProductRankDaily
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ProductRankDailyJpaRepository : JpaRepository<ProductRankDaily, Long>

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/productrank/ProductRankDailyRepositoryImpl.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/productrank/ProductRankDailyRepositoryImpl.kt
@@ -1,0 +1,14 @@
+package com.loopers.infrastructure.productrank
+
+import com.loopers.domain.productrank.ProductRankDaily
+import com.loopers.domain.productrank.ProductRankDailyRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class ProductRankDailyRepositoryImpl(
+    private val productRankDailyJpaRepository: ProductRankDailyJpaRepository,
+) : ProductRankDailyRepository {
+    override fun saveAll(ranks: List<ProductRankDaily>) {
+        productRankDailyJpaRepository.saveAll(ranks)
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/productrank/ProductRankHourlyJpaRepository.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/productrank/ProductRankHourlyJpaRepository.kt
@@ -1,0 +1,6 @@
+package com.loopers.infrastructure.productrank
+
+import com.loopers.domain.productrank.ProductRankHourly
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ProductRankHourlyJpaRepository : JpaRepository<ProductRankHourly, Long>

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/productrank/ProductRankHourlyRepositoryImpl.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/productrank/ProductRankHourlyRepositoryImpl.kt
@@ -1,0 +1,14 @@
+package com.loopers.infrastructure.productrank
+
+import com.loopers.domain.productrank.ProductRankHourly
+import com.loopers.domain.productrank.ProductRankHourlyRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class ProductRankHourlyRepositoryImpl(
+    private val productRankHourlyJpaRepository: ProductRankHourlyJpaRepository,
+) : ProductRankHourlyRepository {
+    override fun saveAll(ranks: List<ProductRankHourly>) {
+        productRankHourlyJpaRepository.saveAll(ranks)
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/consumer/productrank/ProductRankV1EventConsumer.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/consumer/productrank/ProductRankV1EventConsumer.kt
@@ -10,7 +10,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.kafka.support.Acknowledgment
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -29,7 +28,6 @@ class ProductRankV1EventConsumer(
         groupId = EventType.Group.PRODUCT_RANK_DAY_EVENTS,
         containerFactory = KafkaConfig.BATCH_LISTENER,
     )
-    @Transactional
     fun productRankDayEventListen(
         records: List<ConsumerRecord<String, String>>,
         ack: Acknowledgment,
@@ -60,7 +58,6 @@ class ProductRankV1EventConsumer(
         groupId = EventType.Group.PRODUCT_RANK_HOUR_EVENTS,
         containerFactory = KafkaConfig.BATCH_LISTENER,
     )
-    @Transactional
     fun productRankHourEventListen(
         records: List<ConsumerRecord<String, String>>,
         ack: Acknowledgment,

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/consumer/productrank/ProductRankV1EventConsumer.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/consumer/productrank/ProductRankV1EventConsumer.kt
@@ -1,0 +1,84 @@
+package com.loopers.interfaces.consumer.productrank
+
+import com.loopers.config.kakfa.KafkaConfig
+import com.loopers.domain.productrank.ProductRankService
+import com.loopers.event.Event
+import com.loopers.event.EventType
+import com.loopers.support.cache.productrank.ProductRankCacheKeyGenerator
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Component
+class ProductRankV1EventConsumer(
+    private val productRankService: ProductRankService,
+) {
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    @KafkaListener(
+        topics = [
+            EventType.Topic.PRODUCT_V1_STOCK_ADJUSTED,
+            EventType.Topic.PRODUCT_V1_LIKE_CHANGED,
+            EventType.Topic.PRODUCT_V1_VIEWED,
+        ],
+        groupId = EventType.Group.PRODUCT_RANK_DAY_EVENTS,
+        containerFactory = KafkaConfig.BATCH_LISTENER,
+    )
+    @Transactional
+    fun productRankDayEventListen(
+        records: List<ConsumerRecord<String, String>>,
+        ack: Acknowledgment,
+    ) {
+        log.info("[ProductRankV1EventConsumer.productRankDayEventListen] records: $records")
+
+        val eventMap = records
+            .map { Event.fromJson(it.value()) ?: throw IllegalArgumentException("Invalid event message: ${it.value()}") }
+            .groupBy { it.eventType }
+
+        eventMap.forEach { (eventType, events) ->
+            productRankService.handleEvent(
+                ProductRankCacheKeyGenerator.generate(LocalDate.now()),
+                eventType,
+                events.map { it.payload },
+            )
+        }
+
+        ack.acknowledge()
+    }
+
+    @KafkaListener(
+        topics = [
+            EventType.Topic.PRODUCT_V1_STOCK_ADJUSTED,
+            EventType.Topic.PRODUCT_V1_LIKE_CHANGED,
+            EventType.Topic.PRODUCT_V1_VIEWED,
+        ],
+        groupId = EventType.Group.PRODUCT_RANK_HOUR_EVENTS,
+        containerFactory = KafkaConfig.BATCH_LISTENER,
+    )
+    @Transactional
+    fun productRankHourEventListen(
+        records: List<ConsumerRecord<String, String>>,
+        ack: Acknowledgment,
+    ) {
+        log.info("[ProductRankV1EventConsumer.productRankHourEventListen] records: $records")
+
+        val eventMap = records
+            .map { Event.fromJson(it.value()) ?: throw IllegalArgumentException("Invalid event message: ${it.value()}") }
+            .groupBy { it.eventType }
+
+        eventMap.forEach { (eventType, events) ->
+            productRankService.handleEvent(
+                ProductRankCacheKeyGenerator.generate(LocalDateTime.now()),
+                eventType,
+                events.map { it.payload },
+            )
+        }
+
+        ack.acknowledge()
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/scheduler/productrank/ProductRankBackupScheduler.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/scheduler/productrank/ProductRankBackupScheduler.kt
@@ -1,0 +1,30 @@
+package com.loopers.interfaces.scheduler.productrank
+
+import com.loopers.domain.productrank.ProductRankService
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Component
+class ProductRankBackupScheduler(
+    private val productRankService: ProductRankService,
+) {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    @Scheduled(cron = "1 0 0 * * *", zone = "Asia/Seoul")
+    fun backupYesterdayProductRank() {
+        log.info("[ProductRankBackupScheduler.backupYesterdayProductRank] start")
+        productRankService.backupYesterdayProductRank(LocalDate.now().minusDays(1))
+        log.info("[ProductRankBackupScheduler.backupYesterdayProductRank] end")
+    }
+
+    @Scheduled(cron = "1 0 * * * *", zone = "Asia/Seoul")
+    fun backupPrevHourProductRank() {
+        log.info("[ProductRankBackupScheduler.backupPrevHourProductRank] start")
+        productRankService.backupPrevHourProductRank(LocalDateTime.now())
+        log.info("[ProductRankBackupScheduler.backupPrevHourProductRank] end")
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/scheduler/productrank/ProductRankScheduler.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/scheduler/productrank/ProductRankScheduler.kt
@@ -1,0 +1,30 @@
+package com.loopers.interfaces.scheduler.productrank
+
+import com.loopers.domain.productrank.ProductRankCarryOverService
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class ProductRankScheduler(
+    private val productRankCarryOverService: ProductRankCarryOverService,
+) {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    @Scheduled(cron = "0 50 11 * * *", zone = "Asia/Seoul")
+    fun carryOverTomorrowRank() {
+        log.info("[ProductRankScheduler.carryOverTomorrowRank] start")
+        // 상위 20개 상품 랭킹을 carry-over, 점수는 1% 감소
+        productRankCarryOverService.carryOverTomorrowRank(20, 0.01)
+        log.info("[ProductRankScheduler.carryOverTomorrowRank] end")
+    }
+
+    @Scheduled(cron = "0 50 * * * *", zone = "Asia/Seoul")
+    fun carryOverNextHourRank() {
+        log.info("[ProductRankScheduler.carryOverNextHourRank] start")
+        // 상위 20개 상품 랭킹을 carry-over, 점수는 1% 감소
+        productRankCarryOverService.carryOverNextHourRank(20, 0.01)
+        log.info("[ProductRankScheduler.carryOverNextHourRank] end")
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/scheduler/productrank/ProductRankSimulationScheduler.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/scheduler/productrank/ProductRankSimulationScheduler.kt
@@ -1,0 +1,88 @@
+package com.loopers.interfaces.scheduler.productrank
+
+import com.loopers.domain.productrank.ProductRankService
+import com.loopers.event.Event
+import com.loopers.event.EventType
+import com.loopers.event.payload.EventPayload
+import com.loopers.event.payload.product.ProductViewedEvent
+import com.loopers.event.payload.productlike.ProductLikedEvent
+import com.loopers.event.payload.productlike.ProductUnlikedEvent
+import com.loopers.event.payload.stock.StockAdjustedEvent
+import com.loopers.support.cache.productrank.ProductRankCacheKeyGenerator
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Profile("rank-simulation")
+@Component
+class ProductRankSimulationScheduler(
+    private val productRankService: ProductRankService,
+) {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    @Scheduled(cron = "*/1 * * * * *", zone = "Asia/Seoul")
+    fun createProductRankByRandomEvent() {
+        log.info("[ProductRankScheduler.generateRandomEvent] start")
+
+        // Daily
+        val dailyEvent = generateRandomEvent()
+        productRankService.handleEvent(
+            ProductRankCacheKeyGenerator.generate(LocalDate.now()),
+            dailyEvent.eventType,
+            listOf(dailyEvent.payload),
+        )
+
+        // Hourly
+        val hourlyEvent = generateRandomEvent()
+        productRankService.handleEvent(
+            ProductRankCacheKeyGenerator.generate(LocalDateTime.now()),
+            hourlyEvent.eventType,
+            listOf(hourlyEvent.payload),
+        )
+        log.info("[ProductRankScheduler.generateRandomEvent] end")
+    }
+
+    fun generateRandomEvent(): Event<out EventPayload> {
+        return when ((1..4).random()) {
+            1 -> Event(
+                UUID.randomUUID().toString(),
+                EventType.PRODUCT_STOCK_ADJUSTED,
+                StockAdjustedEvent(
+                    (1..30).random().toLong(),
+                    (1..10).random(),
+                    (1000..10000).random().toLong(),
+                ),
+            )
+
+            2 -> Event(
+                UUID.randomUUID().toString(),
+                EventType.PRODUCT_LIKED,
+                ProductLikedEvent(
+                    (1..30).random().toLong(),
+                ),
+            )
+
+            3 -> Event(
+                UUID.randomUUID().toString(),
+                EventType.PRODUCT_UNLIKED,
+                ProductUnlikedEvent(
+                    (1..30).random().toLong(),
+                ),
+            )
+
+            else -> Event(
+                UUID.randomUUID().toString(),
+                EventType.PRODUCT_VIEWED,
+                ProductViewedEvent(
+                    (1..30).random().toLong(),
+                    "product:${(1..30).random()}",
+                ),
+            )
+        }
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/support/cache/CacheKey.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/support/cache/CacheKey.kt
@@ -5,7 +5,7 @@ import java.time.Duration
 object CacheNames {
     const val PRODUCT_DETAIL_V1 = "product:detail:v1:"
     const val PRODUCT_LIKE_COUNT_V1 = "product:like-count:v1:"
-    const val BRAND_DETAIL_V1 = "brand:detail:v1:"
+    const val PRODUCT_RANK_ALL_KEY_PREFIX = "ranking:all:"
 }
 
 class CacheKey(

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/support/cache/CacheRepository.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/support/cache/CacheRepository.kt
@@ -1,9 +1,17 @@
 package com.loopers.support.cache
 
+import org.springframework.data.redis.core.DefaultTypedTuple
+
 interface CacheRepository {
     fun <T> get(cacheKey: CacheKey, clazz: Class<T>): T?
 
     fun <T> set(cacheKey: CacheKey, value: T)
 
     fun evict(key: String)
+
+    fun zIncrBy(cacheKey: CacheKey, productId: Long, score: Double)
+
+    fun findTopRankByScoreDesc(cacheKey: CacheKey, offset: Long, size: Int): Map<String, Double>
+
+    fun zAddAll(cacheKey: CacheKey, normalizedTuples: Set<DefaultTypedTuple<String>>)
 }

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/support/cache/productrank/ProductRankCacheKeyGenerator.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/support/cache/productrank/ProductRankCacheKeyGenerator.kt
@@ -1,0 +1,33 @@
+package com.loopers.support.cache.productrank
+
+import com.loopers.support.cache.CacheKey
+import com.loopers.support.cache.CacheNames
+import com.loopers.support.utils.TimeCalculatorUtils
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+object ProductRankCacheKeyGenerator {
+
+    fun generate(date: LocalDateTime): CacheKey {
+        val formatter = DateTimeFormatter.ofPattern("yyyyMMddHH")
+        val formattedDate = formatter.format(date)
+        return CacheKey(
+            CacheNames.PRODUCT_RANK_ALL_KEY_PREFIX,
+            formattedDate,
+            // ttl 2시간 설정
+            TimeCalculatorUtils.calculateDurationByHours(LocalDateTime.now(), 2),
+        )
+    }
+
+    fun generate(date: LocalDate): CacheKey {
+        val formatter = DateTimeFormatter.ofPattern("yyyyMMdd")
+        val formattedDate = formatter.format(date)
+        return CacheKey(
+            CacheNames.PRODUCT_RANK_ALL_KEY_PREFIX,
+            formattedDate,
+            // ttl 2일로 설정
+            TimeCalculatorUtils.calculateDurationByDays(LocalDateTime.now(), 2),
+        )
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/support/utils/TimeCalculatorUtils.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/support/utils/TimeCalculatorUtils.kt
@@ -1,0 +1,53 @@
+package com.loopers.support.utils
+
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+object TimeCalculatorUtils {
+    /**
+     * N일 뒤 자정(00:00)까지 TTL 계산
+     * 기준: 정오(12:00)
+     * @param days 몇 일 뒤 자정까지 만료시킬지
+     *
+     * 예:
+     * - 25.09.11 11:50 실행, days=2 → 25.09.13 00:00 만료
+     * - 25.09.11 12:10 실행, days=2 → 25.09.14 00:00 만료 (+1일)
+     * - 25.09.11 23:50 실행, days=2 → 25.09.14 00:00 만료 (+1일)
+     */
+    fun calculateDurationByDays(now: LocalDateTime, days: Long): Duration {
+        val noon = LocalTime.NOON
+        val adjustedDays = if (now.toLocalTime().isAfter(noon)) days + 1 else days
+
+        val targetMidnight = now.toLocalDate()
+            .plusDays(adjustedDays)
+            .atStartOfDay()
+
+        return Duration.between(now, targetMidnight)
+    }
+
+    /**
+     * 현재 시간 기준으로 TTL을 hours 시간 뒤 "정시 시각"으로 설정
+     * 30분 기준으로 반올림 처리
+     *
+     * @param hours 몇 시간 뒤를 기준으로 TTL을 설정할지
+     *
+     * 예:
+     * - 01:20 실행, hours=2 → base=03:20 → 03:00 만료 (30분 이전 → 그대로)
+     * - 01:50 실행, hours=2 → base=03:50 → 04:00 만료 (30분 이후 → 올림)
+     * - 02:50 실행, hours=2 → base=04:50 → 05:00 만료 (30분 이후 → 올림)
+     * - 02:10 실행, hours=2 → base=04:10 → 04:00 만료 (30분 이전 → 그대로)
+     */
+    fun calculateDurationByHours(now: LocalDateTime, hours: Long): Duration {
+        val base = now.plusHours(hours)
+
+        // 30분 기준 반올림 처리
+        val rounded = if (base.minute < 30) {
+            base.withMinute(0).withSecond(0).withNano(0)
+        } else {
+            base.withMinute(0).withSecond(0).withNano(0).plusHours(1)
+        }
+
+        return Duration.between(now, rounded)
+    }
+}

--- a/apps/commerce-streamer/src/test/java/com/loopers/domain/productrank/ProductRankKeyGeneratorTest.kt
+++ b/apps/commerce-streamer/src/test/java/com/loopers/domain/productrank/ProductRankKeyGeneratorTest.kt
@@ -1,0 +1,39 @@
+package com.loopers.domain.productrank
+
+import com.loopers.support.cache.productrank.ProductRankCacheKeyGenerator
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class ProductRankKeyGeneratorTest {
+
+    @DisplayName("generate(date: LocalDateTime) 메서드는 yyyyMMddHH 형식으로 키를 생성해야 한다.")
+    @Test
+    fun testGenerateWithLocalDateTime() {
+        // arrange
+        val dateTime = LocalDateTime.of(2024, 6, 15, 14, 30)
+
+        // act
+        val actualKey = ProductRankCacheKeyGenerator.generate(dateTime)
+
+        // assert
+        val expectedKey = "ranking:all:2024061514"
+        assertEquals(expectedKey, actualKey)
+    }
+
+    @DisplayName("generate(date: LocalDate) 메서드는 yyyyMMdd 형식으로 키를 생성해야 한다.")
+    @Test
+    fun testGenerateWithLocalDate() {
+        // arrange
+        val date = LocalDate.of(2024, 6, 15)
+
+        // act
+        val actualKey = ProductRankCacheKeyGenerator.generate(date)
+
+        // assert
+        val expectedKey = "ranking:all:20240615"
+        assertEquals(expectedKey, actualKey)
+    }
+}

--- a/apps/commerce-streamer/src/test/java/com/loopers/support/utils/TimeCalculatorUtilsTest.kt
+++ b/apps/commerce-streamer/src/test/java/com/loopers/support/utils/TimeCalculatorUtilsTest.kt
@@ -1,0 +1,145 @@
+package com.loopers.support.utils
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class TimeCalculatorUtilsTest {
+    @Test
+    @DisplayName("days=2 - 25.09.11 11:50 실행 → 25.09.13 00:00 만료")
+    fun calculateDurationByDays_beforeNoon() {
+        // arrange
+        val now = LocalDateTime.of(2025, 9, 11, 11, 50, 0)
+        val expectedTarget = LocalDate.of(2025, 9, 13).atStartOfDay()
+        val expected = Duration.between(now, expectedTarget)
+
+        // act
+        val actual = TimeCalculatorUtils.calculateDurationByDays(now, 2)
+
+        // assert
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    @DisplayName("days=2 - 25.09.11 12:10 실행 → 25.09.14 00:00 만료 (+1일)")
+    fun calculateDurationByDays_afterNoon() {
+        // arrange
+        val now = LocalDateTime.of(2025, 9, 11, 12, 10, 0)
+        val expectedTarget = LocalDate.of(2025, 9, 14).atStartOfDay()
+        val expected = Duration.between(now, expectedTarget)
+
+        // act
+        val actual = TimeCalculatorUtils.calculateDurationByDays(now, 2)
+
+        // assert
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    @DisplayName("days=2 - 25.09.11 23:50 실행 → 25.09.14 00:00 만료 (+1일)")
+    fun calculateDurationByDays_nearMidnight() {
+        // arrange
+        val now = LocalDateTime.of(2025, 9, 11, 23, 50, 0)
+        val expectedTarget = LocalDate.of(2025, 9, 14).atStartOfDay()
+        val expected = Duration.between(now, expectedTarget)
+
+        // act
+        val actual = TimeCalculatorUtils.calculateDurationByDays(now, 2)
+
+        // assert
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    @DisplayName("hours=2 - 01:50 실행 → 04:00 만료 (2h10m)")
+    fun calculateDurationByHours_roundsUpToNextHour() {
+        // arrange
+        val now = LocalDateTime.of(2025, 9, 12, 1, 50, 0)
+        val expectedTarget = LocalDateTime.of(2025, 9, 12, 4, 0, 0)
+        val expected = Duration.between(now, expectedTarget)
+
+        // act
+        val actual = TimeCalculatorUtils.calculateDurationByHours(now, 2)
+
+        // assert
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    @DisplayName("hours=2 - 02:50 실행 → 05:00 만료 (2h10m)")
+    fun calculateDurationByHours_roundsUpToNextHour_case2() {
+        // arrange
+        val now = LocalDateTime.of(2025, 9, 12, 2, 50, 0)
+        val expectedTarget = LocalDateTime.of(2025, 9, 12, 5, 0, 0)
+        val expected = Duration.between(now, expectedTarget)
+
+        // act
+        val actual = TimeCalculatorUtils.calculateDurationByHours(now, 2)
+
+        // assert
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    @DisplayName("hours=2 - 03:00 실행 → 05:00 만료 (정시 그대로)")
+    fun calculateDurationByHours_exactHour() {
+        // arrange
+        val now = LocalDateTime.of(2025, 9, 12, 3, 0, 0)
+        val expectedTarget = LocalDateTime.of(2025, 9, 12, 5, 0, 0)
+        val expected = Duration.between(now, expectedTarget)
+
+        // act
+        val actual = TimeCalculatorUtils.calculateDurationByHours(now, 2)
+
+        // assert
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    @DisplayName("hours=2 - 23:10 실행 → 다음날 01:00 만료")
+    fun calculateDurationByHours_crossesMidnight() {
+        // arrange
+        val now = LocalDateTime.of(2025, 9, 12, 23, 10, 0)
+        val expectedTarget = LocalDateTime.of(2025, 9, 13, 1, 0, 0)
+        val expected = Duration.between(now, expectedTarget)
+
+        // act
+        val actual = TimeCalculatorUtils.calculateDurationByHours(now, 2)
+
+        // assert
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    @DisplayName("hours=2 - 01:20 실행 → base=03:20 → 03:00 만료 (30분 이전)")
+    fun calculateDurationByHours_before30min() {
+        // arrange
+        val now = LocalDateTime.of(2025, 9, 12, 1, 20, 0)
+        val expectedTarget = LocalDateTime.of(2025, 9, 12, 3, 0, 0)
+        val expected = Duration.between(now, expectedTarget)
+
+        // act
+        val actual = TimeCalculatorUtils.calculateDurationByHours(now, 2)
+
+        // assert
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    @DisplayName("hours=2 - 01:50 실행 → base=03:50 → 04:00 만료 (30분 이후)")
+    fun calculateDurationByHours_after30min() {
+        // arrange
+        val now = LocalDateTime.of(2025, 9, 12, 1, 50, 0)
+        val expectedTarget = LocalDateTime.of(2025, 9, 12, 4, 0, 0)
+        val expected = Duration.between(now, expectedTarget)
+
+        // act
+        val actual = TimeCalculatorUtils.calculateDurationByHours(now, 2)
+
+        // assert
+        assertEquals(expected, actual)
+    }
+}

--- a/data/ddl.sql
+++ b/data/ddl.sql
@@ -1,0 +1,257 @@
+create table brand
+(
+    created_at datetime(6)                           not null,
+    deleted_at datetime(6)                           null,
+    id         bigint auto_increment
+        primary key,
+    updated_at datetime(6)                           not null,
+    name       varchar(255)                          null,
+    status     enum ('ACTIVE', 'CLOSED', 'INACTIVE') null,
+    constraint UKrdxh7tq2xs66r485cc8dkxt77
+        unique (name)
+);
+
+create table coupon
+(
+    value      double                       null,
+    created_at datetime(6)                  not null,
+    deleted_at datetime(6)                  null,
+    id         bigint auto_increment
+        primary key,
+    price      bigint                       null,
+    updated_at datetime(6)                  not null,
+    name       varchar(255)                 null,
+    status     enum ('ACTIVE', 'INACTIVE')  null,
+    type       enum ('FIXED', 'PERCENTAGE') null
+);
+
+create table event_handled
+(
+    event_type     tinyint                    null,
+    partition_no   int                        not null,
+    created_at     datetime(6)                not null,
+    deleted_at     datetime(6)                null,
+    id             bigint auto_increment
+        primary key,
+    offset_no      bigint                     not null,
+    updated_at     datetime(6)                not null,
+    consumer_group varchar(255)               null,
+    event_id       varchar(255)               null,
+    topic          varchar(255)               null,
+    status         enum ('FAILED', 'SUCCEED') null,
+    check (`event_type` between 0 and 5)
+);
+
+create table event_log
+(
+    partition_no int                                                                                                                                not null,
+    created_at   datetime(6)                                                                                                                        not null,
+    deleted_at   datetime(6)                                                                                                                        null,
+    id           bigint auto_increment
+        primary key,
+    offset_no    bigint                                                                                                                             not null,
+    updated_at   datetime(6)                                                                                                                        not null,
+    event_id     varchar(255)                                                                                                                       null,
+    payload      varchar(255)                                                                                                                       null,
+    topic        varchar(255)                                                                                                                       null,
+    event_type   enum ('PRODUCT_CHANGED', 'PRODUCT_LIKED', 'PRODUCT_STOCK_ADJUSTED', 'PRODUCT_STOCK_SOLD_OUT', 'PRODUCT_UNLIKED', 'PRODUCT_VIEWED') null
+);
+
+create table issued_coupon
+(
+    coupon_id  bigint                  not null,
+    created_at datetime(6)             not null,
+    deleted_at datetime(6)             null,
+    id         bigint auto_increment
+        primary key,
+    issued_at  datetime(6)             null,
+    updated_at datetime(6)             not null,
+    used_at    datetime(6)             null,
+    user_id    bigint                  not null,
+    status     enum ('ACTIVE', 'USED') null
+);
+
+create table member
+(
+    created_at datetime(6)     not null,
+    deleted_at datetime(6)     null,
+    id         bigint auto_increment
+        primary key,
+    updated_at datetime(6)     not null,
+    birthday   varchar(255)    null,
+    email      varchar(255)    not null,
+    name       varchar(255)    null,
+    username   varchar(255)    not null,
+    gender     enum ('F', 'M') null,
+    constraint UKgc3jmn7c2abyo3wf6syln5t2i
+        unique (username),
+    constraint UKmbmcqelty0fbrvxp1q58dn57t
+        unique (email)
+);
+
+create table orders
+(
+    amount           bigint                                              null,
+    created_at       datetime(6)                                         not null,
+    deleted_at       datetime(6)                                         null,
+    id               bigint auto_increment
+        primary key,
+    issued_coupon_id bigint                                              null,
+    price            bigint                                              null,
+    total_price      bigint                                              null,
+    updated_at       datetime(6)                                         not null,
+    user_id          bigint                                              not null,
+    address          varchar(255)                                        null,
+    address_detail   varchar(255)                                        null,
+    email            varchar(255)                                        null,
+    mobile           varchar(255)                                        null,
+    name             varchar(255)                                        null,
+    order_key        varchar(255)                                        null,
+    zip_code         varchar(255)                                        null,
+    order_status     enum ('CANCELED', 'COMPLETED', 'FAILED', 'PENDING') null
+);
+
+create table order_item
+(
+    amount     bigint      null,
+    created_at datetime(6) not null,
+    deleted_at datetime(6) null,
+    id         bigint auto_increment
+        primary key,
+    order_id   bigint      null,
+    product_id bigint      not null,
+    updated_at datetime(6) not null,
+    constraint FKt4dc2r9nbvbujrljv3e23iibt
+        foreign key (order_id) references orders (id)
+);
+
+create table payment
+(
+    card_type       tinyint                                             null,
+    created_at      datetime(6)                                         not null,
+    deleted_at      datetime(6)                                         null,
+    id              bigint auto_increment
+        primary key,
+    order_id        bigint                                              not null,
+    price           bigint                                              null,
+    updated_at      datetime(6)                                         not null,
+    user_id         bigint                                              not null,
+    card_no         varchar(255)                                        null,
+    order_key       varchar(255)                                        null,
+    reason          varchar(255)                                        null,
+    transaction_key varchar(255)                                        null,
+    method          enum ('CARD', 'POINT')                              null,
+    status          enum ('CANCELED', 'COMPLETED', 'FAILED', 'PENDING') null,
+    check (`card_type` between 0 and 2)
+);
+
+create table point
+(
+    created_at datetime(6) not null,
+    deleted_at datetime(6) null,
+    id         bigint auto_increment
+        primary key,
+    point      bigint      not null,
+    updated_at datetime(6) not null,
+    user_id    bigint      not null,
+    version    bigint      null,
+    constraint UKhq78fkgkdiel9lydwbq8vu9bt
+        unique (user_id)
+);
+
+create table product
+(
+    brand_id    bigint                                 not null,
+    created_at  datetime(6)                            not null,
+    deleted_at  datetime(6)                            null,
+    id          bigint auto_increment
+        primary key,
+    price       bigint                                 null,
+    updated_at  datetime(6)                            not null,
+    description varchar(255)                           null,
+    name        varchar(255)                           null,
+    status      enum ('ACTIVE', 'DELETED', 'INACTIVE') null
+);
+
+create table product_like
+(
+    created_at datetime(6) not null,
+    deleted_at datetime(6) null,
+    id         bigint auto_increment
+        primary key,
+    product_id bigint      not null,
+    updated_at datetime(6) not null,
+    user_id    bigint      not null,
+    constraint UK37ktf1twpt25939lf23nwwot
+        unique (user_id, product_id)
+);
+
+create table product_like_count
+(
+    product_like_count int         not null,
+    created_at         datetime(6) not null,
+    deleted_at         datetime(6) null,
+    product_id         bigint      not null
+        primary key,
+    updated_at         datetime(6) not null,
+    version            bigint      null
+);
+
+create table product_metrics
+(
+    like_count  int         not null,
+    metric_date date        null,
+    sales_count int         not null,
+    view_count  int         not null,
+    created_at  datetime(6) not null,
+    deleted_at  datetime(6) null,
+    id          bigint auto_increment
+        primary key,
+    product_id  bigint      not null,
+    updated_at  datetime(6) not null,
+    constraint uk_product_metrics_product_date
+        unique (product_id, metric_date)
+);
+
+create index idx_product_metrics_metric_date
+    on product_metrics (metric_date);
+
+create index idx_product_metrics_product_id
+    on product_metrics (product_id);
+
+create table product_rank_daily
+(
+    rank_date   date         null,
+    rank_number int          not null,
+    score       double       not null,
+    created_at  datetime(6)  not null,
+    deleted_at  datetime(6)  null,
+    id          bigint auto_increment
+        primary key,
+    updated_at  datetime(6)  not null,
+    product_id  varchar(255) null
+);
+
+create table product_rank_hourly
+(
+    rank_number    int          not null,
+    score          double       not null,
+    created_at     datetime(6)  not null,
+    deleted_at     datetime(6)  null,
+    id             bigint auto_increment
+        primary key,
+    rank_date_time datetime(6)  null,
+    updated_at     datetime(6)  not null,
+    product_id     varchar(255) null
+);
+
+create table stock
+(
+    quantity   int         not null,
+    created_at datetime(6) not null,
+    deleted_at datetime(6) null,
+    product_id bigint      not null
+        primary key,
+    updated_at datetime(6) not null
+);
+

--- a/docs/rank/README.md
+++ b/docs/rank/README.md
@@ -1,0 +1,17 @@
+## 상품 랭킹 시뮬레이션 환경 구성
+
+### 1. 사전 데이터 설정
+- `ddl-auto: none`으로 설정되어 있어 `commerce-api` 실행 후 ddl, dml 스크립트 실행
+    - [ddl.sql](../../data/ddl.sql)
+    - [brand.sql](../../data/brand.sql)
+    - [member.sql](../../data/member.sql)
+    - [product.sql](../../data/product.sql)
+    - [product_like_count.sql](../../data/product_like_count.sql)
+
+### 2. 구동 및 접속 경로
+- `commerce-api` 실행
+- `commerce-streamer` 실행
+    - 실행 시 `profiles=local,rank-simulation` 추가 후 실행
+- 접속 경로
+    - 일별 랭킹: `http://localhost:8080/rankings/daily`
+    - 시간별 랭킹: `http://localhost:8080/rankings/hourly`

--- a/modules/event/src/main/kotlin/com/loopers/event/EventType.kt
+++ b/modules/event/src/main/kotlin/com/loopers/event/EventType.kt
@@ -41,6 +41,8 @@ enum class EventType(
         companion object {
             const val CATALOG_EVENTS = "catalog-events-consumer"
             const val METRICS_EVENTS = "metrics-events-consumer"
+            const val PRODUCT_RANK_DAY_EVENTS = "product-rank-day-consumer"
+            const val PRODUCT_RANK_HOUR_EVENTS = "product-rank-hour-consumer"
             const val AUDIT_LOG_EVENTS = "audit-log-events-consumer"
 
             // DLT

--- a/modules/event/src/main/kotlin/com/loopers/event/payload/stock/StockAdjustedEvent.kt
+++ b/modules/event/src/main/kotlin/com/loopers/event/payload/stock/StockAdjustedEvent.kt
@@ -5,4 +5,5 @@ import com.loopers.event.payload.EventPayload
 data class StockAdjustedEvent(
     val productId: Long,
     val quantity: Int,
+    val amount: Long,
 ) : EventPayload

--- a/modules/jpa/src/main/resources/jpa.yml
+++ b/modules/jpa/src/main/resources/jpa.yml
@@ -37,7 +37,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: none
 
 datasource:
   mysql-jpa:


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->

- [`ProductRankCacheKeyGenerator`](https://github.com/kiekk/gamsung-commerce/blob/47976e53a9592f8154787a44836befc44f067e44/apps/commerce-streamer/src/main/kotlin/com/loopers/support/cache/productrank/ProductRankCacheKeyGenerator.kt)를 통해 상품 랭킹 키 생성/관리 기능 구현

- [`ProductRankScoreCalculator`](https://github.com/kiekk/gamsung-commerce/blob/47976e53a9592f8154787a44836befc44f067e44/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/ProductRankScoreCalculator.kt)를 통해 상품 랭킹 가중치 계산 로직 분리

- 시뮬레이션 환경 구성으로 실시간 랭킹 반영 정상 동작 검증
  - `thymeleaf`, `htmx`, `scheduler`를 사용하여 시뮬레이션 환경을 구성했습니다.
  - [시뮬레이션 환경 구성 방법](https://github.com/kiekk/gamsung-commerce/blob/61e88129dfcc3e7fbe178f12b898add4a15e176f/docs/rank/README.md)
  - 접속 경로
    - 일별 랭킹: `http://localhost:8080/rankings/daily`
    - 시간별 랭킹: `http://localhost:8080/rankings/hourly`

https://github.com/user-attachments/assets/e296cf4a-6810-427a-a654-0d6d75ce2e7f

## 💬 Review Points
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
-->

# 1. 상품 랭킹 집계 일별/시간별 consumer 분리
- `product_metrics` 컨슈머에서 상품 랭킹까지 처리하기에는 역할/책임이 맞지 않다고 판단했습니다.
- 그래서 `product_rank`라는 별도 컨슈머를 만들고, 이를 일별/시간별로 다시 분리했습니다.
- 이렇게 Consumer를 분리하는 접근이 적절한지 궁금합니다.

```kotlin
@KafkaListener(
    topics = [
        EventType.Topic.PRODUCT_V1_STOCK_ADJUSTED,
        EventType.Topic.PRODUCT_V1_LIKE_CHANGED,
        EventType.Topic.PRODUCT_V1_VIEWED,
    ],
    groupId = EventType.Group.PRODUCT_RANK_DAY_EVENTS,
    containerFactory = KafkaConfig.BATCH_LISTENER,
)
fun productRankDayEventListen(
    records: List<ConsumerRecord<String, String>>,
    ack: Acknowledgment,
) {
    log.info("[ProductRankV1EventConsumer.productRankDayEventListen] records: $records")

    val eventMap = records
        .map { Event.fromJson(it.value()) ?: throw IllegalArgumentException("Invalid event message: ${it.value()}") }
        .groupBy { it.eventType }

    eventMap.forEach { (eventType, events) ->
        productRankService.handleEvent(
            ProductRankCacheKeyGenerator.generate(LocalDate.now()),
            eventType,
            events.map { it.payload },
        )
    }

    ack.acknowledge()
}

@KafkaListener(
    topics = [
        EventType.Topic.PRODUCT_V1_STOCK_ADJUSTED,
        EventType.Topic.PRODUCT_V1_LIKE_CHANGED,
        EventType.Topic.PRODUCT_V1_VIEWED,
    ],
    groupId = EventType.Group.PRODUCT_RANK_HOUR_EVENTS,
    containerFactory = KafkaConfig.BATCH_LISTENER,
)
fun productRankHourEventListen(
    records: List<ConsumerRecord<String, String>>,
    ack: Acknowledgment,
) {
    log.info("[ProductRankV1EventConsumer.productRankHourEventListen] records: $records")

    val eventMap = records
        .map { Event.fromJson(it.value()) ?: throw IllegalArgumentException("Invalid event message: ${it.value()}") }
        .groupBy { it.eventType }

    eventMap.forEach { (eventType, events) ->
        productRankService.handleEvent(
            ProductRankCacheKeyGenerator.generate(LocalDateTime.now()),
            eventType,
            events.map { it.payload },
        )
    }

    ack.acknowledge()
}
```

# 2. Carry-Over에 따른 TTL 설정
- 초기에는 단순히 `Duration.ofDays()`, `Duration.ofHours()`로 TTL을 설정했는데, carry-over 시점 문제로 TTL이 어긋나는 경우가 있었습니다.
- 개선을 위해 기준 시간을 정해 TTL을 계산했습니다.
  - 일별: 정오 이전 carry-over → 오늘 날짜 기준 TTL, 정오 이후 → 다음날 기준 TTL
  - 시간별: 30분 이전 carry-over → 현재 시각 기준 TTL, 30분 이후 → 다음 시각 기준 TTL
- 실무에서는 보통 TTL 적용 시점을 어떤 기준으로 잡으시는지 궁금합니다.

```kotlin
object ProductRankCacheKeyGenerator {

    fun generate(date: LocalDateTime): CacheKey {
        val formatter = DateTimeFormatter.ofPattern("yyyyMMddHH")
        val formattedDate = formatter.format(date)
        return CacheKey(
            CacheNames.PRODUCT_RANK_ALL_KEY_PREFIX,
            formattedDate,
            // ttl 2시간 설정
            TimeCalculatorUtils.calculateDurationByHours(LocalDateTime.now(), 2),
        )
    }

    fun generate(date: LocalDate): CacheKey {
        val formatter = DateTimeFormatter.ofPattern("yyyyMMdd")
        val formattedDate = formatter.format(date)
        return CacheKey(
            CacheNames.PRODUCT_RANK_ALL_KEY_PREFIX,
            formattedDate,
            // ttl 2일로 설정
            TimeCalculatorUtils.calculateDurationByDays(LocalDateTime.now(), 2),
        )
    }
}

object TimeCalculatorUtils {
    /**
     * N일 뒤 자정(00:00)까지 TTL 계산
     * 기준: 정오(12:00)
     * @param days 몇 일 뒤 자정까지 만료시킬지
     *
     * 예:
     * - 25.09.11 11:50 실행, days=2 → 25.09.13 00:00 만료
     * - 25.09.11 12:10 실행, days=2 → 25.09.14 00:00 만료 (+1일)
     * - 25.09.11 23:50 실행, days=2 → 25.09.14 00:00 만료 (+1일)
     */
    fun calculateDurationByDays(now: LocalDateTime, days: Long): Duration {
        val noon = LocalTime.NOON
        val adjustedDays = if (now.toLocalTime().isAfter(noon)) days + 1 else days

        val targetMidnight = now.toLocalDate()
            .plusDays(adjustedDays)
            .atStartOfDay()

        return Duration.between(now, targetMidnight)
    }

    /**
     * 현재 시간 기준으로 TTL을 hours 시간 뒤 "정시 시각"으로 설정
     * 30분 기준으로 반올림 처리
     *
     * @param hours 몇 시간 뒤를 기준으로 TTL을 설정할지
     *
     * 예:
     * - 01:20 실행, hours=2 → base=03:20 → 03:00 만료 (30분 이전 → 그대로)
     * - 01:50 실행, hours=2 → base=03:50 → 04:00 만료 (30분 이후 → 올림)
     * - 02:50 실행, hours=2 → base=04:50 → 05:00 만료 (30분 이후 → 올림)
     * - 02:10 실행, hours=2 → base=04:10 → 04:00 만료 (30분 이전 → 그대로)
     */
    fun calculateDurationByHours(now: LocalDateTime, hours: Long): Duration {
        val base = now.plusHours(hours)

        // 30분 기준 반올림 처리
        val rounded = if (base.minute < 30) {
            base.withMinute(0).withSecond(0).withNano(0)
        } else {
            base.withMinute(0).withSecond(0).withNano(0).plusHours(1)
        }

        return Duration.between(now, rounded)
    }
}
```

# 3. Carry-Over 시 정규화 수치 설정
- 전일 랭킹을 오늘로 carry-over할 때, score를 높게 주면 랭킹이 왜곡될 수 있다고 생각했습니다.
- 그래서 신규 데이터가 자연스럽게 반영되도록 score를 미세하게(예: 0.01) 낮춰서 넣었습니다.
- 이런 정규화 방식이 적절할지 궁금합니다.

```kotlin
@Service
class ProductRankCarryOverService(
    private val cacheRepository: CacheRepository,
) {

    private val log = LoggerFactory.getLogger(this::class.java)

    fun carryOverTomorrowRank(topN: Int, normalize: Double) {
        log.info("[ProductRankCarryOverService.carryOverTomorrowRank] topN: {}, normalize: {}", topN, normalize)
        val today = LocalDate.now()
        val tomorrow = today.plusDays(1)

        val productRanksWithScore = cacheRepository.findTopRankByScoreDesc(ProductRankCacheKeyGenerator.generate(today), 0, topN)

        val normalizedTuples = productRanksWithScore.map { (productId, score) ->
            DefaultTypedTuple(productId, score * normalize)
        }.toSet()

        if (normalizedTuples.isEmpty()) {
            log.info("[ProductRankCarryOverService.carryOverTomorrowRank] 상품 랭킹이 비어있습니다. 오늘 날짜: {}", today)
            return
        }

        cacheRepository.zAddAll(ProductRankCacheKeyGenerator.generate(tomorrow), normalizedTuples)
    }

    fun carryOverNextHourRank(topN: Int, normalize: Double) {
        log.info("[ProductRankCarryOverService.carryOverNextHourRank] topN: {}, normalize: {}", topN, normalize)
        val now = LocalDateTime.now()
        val nextHour = now.plusHours(1)

        val productRanksWithScore = cacheRepository.findTopRankByScoreDesc(ProductRankCacheKeyGenerator.generate(now), 0, topN)

        val normalizedTuples = productRanksWithScore.map { (productId, score) ->
            DefaultTypedTuple(productId, score * normalize)
        }.toSet()

        if (normalizedTuples.isEmpty()) {
            log.info("[ProductRankCarryOverService.carryOverNextHourRank] 상품 랭킹이 비어있습니다. 현재 시간: {}", now)
            return
        }

        cacheRepository.zAddAll(ProductRankCacheKeyGenerator.generate(nextHour), normalizedTuples)
    }
}
```

# 4. 상품 랭킹 집계 DB Backup 기능 구현
- 상품 랭킹은 Redis TTL 만료 후 소멸되므로, TTL 만료 전에 DB에 영속화하려 했습니다.
- 다만 모든 랭킹을 저장하는 것은 비효율적이라 Top-N(예: 100건)만 저장하려고 했습니다. (또는 상위 10%, 15% ...도 가능)
- 실무에서는 랭킹 데이터를 백업/영속화할 때 어떤 기준으로 하시는지 궁금합니다.

```kotlin
@Service
class ProductRankService(
    private val productRankEventHandlerFactory: ProductRankEventHandlerFactory,
    private val cacheRepository: CacheRepository,
    private val productRankDailyRepository: ProductRankDailyRepository,
    private val productRankHourlyRepository: ProductRankHourlyRepository,
) {

    private val log = LoggerFactory.getLogger(this::class.java)

    fun backupYesterdayProductRank(prevDate: LocalDate) {
        log.info("[ProductRankService.backupYesterdayProductRank] prevDate: $prevDate")
        val cacheKey = ProductRankCacheKeyGenerator.generate(prevDate)
        val yesterdayProductRanks = cacheRepository.findTopRankByScoreDesc(
            cacheKey,
            0,
            100,
        )

        val productRankDailies = mutableListOf<ProductRankDaily>()
        yesterdayProductRanks.onEachIndexed { index, productRank ->
            productRankDailies.add(
                ProductRankDaily(
                    productRank.key,
                    cacheKey.key,
                    index + 1,
                    productRank.value,
                ),
            )
        }

        productRankDailyRepository.saveAll(productRankDailies)
    }

    fun backupPrevHourProductRank(prevHours: LocalDateTime) {
        log.info("[ProductRankService.backupPrevHourProductRank] prevHours: $prevHours")
        val cacheKey = ProductRankCacheKeyGenerator.generate(prevHours)
        val prevHourProductRanks = cacheRepository.findTopRankByScoreDesc(
            cacheKey,
            0,
            100,
        )

        val productRankHourlies = mutableListOf<ProductRankHourly>()
        prevHourProductRanks.onEachIndexed { index, productRank ->
            productRankHourlies.add(
                ProductRankHourly(
                    productRank.key,
                    cacheKey.key,
                    index + 1,
                    productRank.value,
                ),
            )
        }

        productRankHourlyRepository.saveAll(productRankHourlies)
    }
}
```

# 5. Score 가중치 실시간 조정 관련 고민
- 현재는 가중치가 코드에 하드코딩되어 있어 실시간 변경이 불가능합니다.
- 실시간 조정을 위해 가중치를 DB에 저장하고, 집계 시점에 읽어오는 방식이 필요하다고 생각했습니다.
- 이때 단일 체계로 관리할 경우 시간별 가중치 변경이 일별 집계에도 영향을 미치는 문제가 있어, 타입(Daily, Hourly)을 구분하는 것이 더 적절하다고 판단했습니다.
- 다만, 다음 집계 시점에 사용할 가중치 정보가 사전에 등록되지 않은 경우 어떻게 처리하는 것이 바람직할지 고민이 됩니다.
- 멘토님은 타입을 구분하는 방식에 대해 어떻게 생각하시고, 미등록된 가중치 처리에 대해서는 어떤 접근을 권장하시는지 궁금합니다.

```kotlin
object ProductRankScoreWeight {
    const val PRODUCT_VIEW_COUNT_WEIGHT: Double = 0.1 // 조회수 가중치
    const val PRODUCT_LIKE_COUNT_WEIGHT: Double = 0.3 // 좋아요수 가중치
    const val PRODUCT_SALES_COUNT_WEIGHT: Double = 0.7 // 판매량수 가중치
}

object ProductRankScoreCalculator {
    fun calculateScoreByViewCount(viewCount: Int): Double {
        return viewCount * ProductRankScoreWeight.PRODUCT_VIEW_COUNT_WEIGHT
    }

    fun calculateScoreByLikeCount(likeCount: Int): Double {
        return likeCount * ProductRankScoreWeight.PRODUCT_LIKE_COUNT_WEIGHT
    }

    fun calculateScoreBySalesCount(salesCount: Int, amount: Long): Double {
        return log10((salesCount * amount) * ProductRankScoreWeight.PRODUCT_SALES_COUNT_WEIGHT)
    }
}
```

# 6. 다건 처리를 위한 배치 리스너 + `Zip-Map-Sink` 구현
- 배치 리스너로 메시지를 모아 받아도 단순 반복 처리만 하면 효과가 없다고 생각했습니다.
- 그래서 Zip-Map-Sink로 쓰기 연산을 최적화했는데, 현재는 각 컨슈머에서 직접 구현하고 있습니다.
- 별도의 도메인 객체를 만들어 `Zip-Map-Sink`를 공통 처리하는 게 더 적절할까요?

```kotlin
val eventMap = records
    .map { Event.fromJson(it.value()) ?: throw IllegalArgumentException("Invalid event message: ${it.value()}") }
    .groupBy { it.eventType }

eventMap.forEach { (eventType, events) ->
    productRankService.handleEvent(
        ProductRankCacheKeyGenerator.generate(LocalDate.now()),
        eventType,
        events.map { it.payload },
    )
}
```

## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->

### 📈 Ranking Consumer

- [x]  랭킹 ZSET 의 TTL, 키 전략을 적절하게 구성하였다
  - [ProductRankCacheKeyGenerator](https://github.com/kiekk/gamsung-commerce/blob/47976e53a9592f8154787a44836befc44f067e44/apps/commerce-streamer/src/main/kotlin/com/loopers/support/cache/productrank/ProductRankCacheKeyGenerator.kt)
  - [TimeCalculatorUtils](https://github.com/kiekk/gamsung-commerce/blob/47976e53a9592f8154787a44836befc44f067e44/apps/commerce-streamer/src/test/java/com/loopers/support/utils/TimeCalculatorUtilsTest.kt)
- [x]  날짜별로 적재할 키를 계산하는 기능을 만들었다
  - [ProductRankCacheKeyGenerator](https://github.com/kiekk/gamsung-commerce/blob/47976e53a9592f8154787a44836befc44f067e44/apps/commerce-streamer/src/main/kotlin/com/loopers/support/cache/productrank/ProductRankCacheKeyGenerator.kt)
- [x]  이벤트가 발생한 후, ZSET 에 점수가 적절하게 반영된다
  - [ProductRankScoreCalculator](https://github.com/kiekk/gamsung-commerce/blob/47976e53a9592f8154787a44836befc44f067e44/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/productrank/ProductRankScoreCalculator.kt)
  - [CacheRedisRepository](https://github.com/kiekk/gamsung-commerce/blob/47976e53a9592f8154787a44836befc44f067e44/apps/commerce-streamer/src/main/kotlin/com/loopers/support/cache/CacheRedisRepository.kt)

### ⚾ Ranking API

- [x]  랭킹 Page 조회 시 정상적으로 랭킹 정보가 반환된다
  - [ProductRankV1Controller](https://github.com/kiekk/gamsung-commerce/blob/47976e53a9592f8154787a44836befc44f067e44/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/productrank/ProductRankV1Controller.kt)
- [x]  랭킹 Page 조회 시 단순히 상품 ID 가 아닌 상품정보가 Aggregation 되어 제공된다
  - [ProductRankFacade](https://github.com/kiekk/gamsung-commerce/blob/47976e53a9592f8154787a44836befc44f067e44/apps/commerce-api/src/main/kotlin/com/loopers/application/productrank/ProductRankFacade.kt)
- [x]  상품 상세 조회 시 해당 상품의 순위가 함께 반환된다 (순위에 없다면 null)
  - [ProductFacade](https://github.com/kiekk/gamsung-commerce/pull/64/files#diff-dad9eb421e957d2184d344b9fc2ff5b59ec61dbe43803c8a32bdc658f65da6eeR60)

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->